### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
   package-test:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Potential fix for [https://github.com/nordstad/zigporter/security/code-scanning/1](https://github.com/nordstad/zigporter/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block either at the workflow root or for each job, granting only the scopes actually required. Since the `test` job already defines its own `permissions`, the simplest and least disruptive change is to add a minimal `permissions` block to the `package-test` job.

Concretely, in `.github/workflows/ci.yml`, under the `package-test:` job (around line 64), add a `permissions:` section with `contents: read`. This ensures that `GITHUB_TOKEN` for this job is limited to read-only access to repository contents, which is sufficient for actions/checkout and does not alter any existing functionality of the steps. No imports or additional methods are required because this is purely a workflow YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
