### PR TITLE
fix: detect wrong device joining Z2M, force-continue at timeout, fix 7-step wizard

### DIFF
--- a/src/zigporter/commands/migrate.py
+++ b/src/zigporter/commands/migrate.py
@@ -19,6 +19,7 @@ from zigporter.migration_state import (
     save_state,
 )
 from zigporter.models import ZHADevice, ZHAExport
+from zigporter.utils import normalize_ieee
 from zigporter.z2m_client import Z2MClient
 
 console = Console()
@@ -38,7 +39,7 @@ _STYLE = questionary.Style(
     ]
 )
 
-WIZARD_STEPS = 6
+WIZARD_STEPS = 7
 
 # Zigbee PermitJoin duration is an 8-bit field; 255 = always-on, so 254 is the
 # practical maximum for a timed window.  Requests larger than this are silently
@@ -248,6 +249,15 @@ async def step_pair_with_z2m(
     console.print(f"\nTrigger [bold]{device.name}[/bold] to join now...")
     console.print(f"Waiting for device [dim]{device.ieee}[/dim] to appear in Z2M...\n")
 
+    # Snapshot the device list before polling so we can detect unexpected joiners.
+    try:
+        known_iees: set[str] = {
+            normalize_ieee(d.get("ieee_address", "")) for d in await z2m_client.get_devices()
+        }
+    except Exception:
+        known_iees = set()
+    target_ieee = normalize_ieee(device.ieee)
+
     elapsed = 0
     poll_interval = 3
     pj_started_at = 0  # elapsed seconds when permit join was last issued
@@ -270,7 +280,28 @@ async def step_pair_with_z2m(
             f"  ⠸ Listening for new device  [{remaining:03d}s remaining]",
             end="\r",
         )
-        z2m_device = await z2m_client.get_device_by_ieee(device.ieee)
+        try:
+            all_devices = await z2m_client.get_devices()
+        except Exception:
+            all_devices = []
+
+        # Detect unexpected joiners: a new device appeared but it's not the one we want.
+        for d in all_devices:
+            d_ieee = normalize_ieee(d.get("ieee_address", ""))
+            if d_ieee and d_ieee not in known_iees and d_ieee != target_ieee:
+                console.print(
+                    f"\n  [yellow]⚠ A different device joined Z2M:[/yellow] "
+                    f"[dim]{d.get('ieee_address')}[/dim] "
+                    f"([bold]{d.get('friendly_name')}[/bold])\n"
+                    f"  This is NOT [bold]{device.name}[/bold]. "
+                    f"Put the correct device in pairing mode."
+                )
+                known_iees.add(d_ieee)  # suppress repeat warnings for the same interloper
+
+        z2m_device = next(
+            (d for d in all_devices if normalize_ieee(d.get("ieee_address", "")) == target_ieee),
+            None,
+        )
         if z2m_device:
             console.print(
                 f"\n[green]✓ Device found in Z2M:[/green] "
@@ -280,10 +311,42 @@ async def step_pair_with_z2m(
             return z2m_device
 
     await z2m_client.disable_permit_join()
-    console.print("\n[yellow]Timed out waiting for device.[/yellow]")
-    retry = await questionary.confirm("Retry pairing?", style=_STYLE).unsafe_ask_async()
-    if retry:
+    console.print(f"\n[yellow]Timed out waiting for[/yellow] [dim]{device.ieee}[/dim]")
+    choice = await questionary.select(
+        "How would you like to proceed?",
+        choices=[
+            questionary.Choice("Retry — poll for another 5 minutes", value="retry"),
+            questionary.Choice(
+                "Force continue — I can see the device joined Z2M (green interview)",
+                value="force",
+            ),
+            questionary.Choice("Mark as failed — revisit this device later", value="fail"),
+        ],
+        style=_STYLE,
+    ).unsafe_ask_async()
+
+    if choice == "retry":
         return await step_pair_with_z2m(device, z2m_client, timeout)
+    if choice == "force":
+        # One final attempt to pick up the device from the Z2M API
+        try:
+            z2m_device = await z2m_client.get_device_by_ieee(device.ieee)
+        except Exception:
+            z2m_device = None
+        if z2m_device:
+            console.print(
+                f"[green]✓ Device found in Z2M:[/green] "
+                f"[bold]{z2m_device.get('friendly_name')}[/bold]"
+            )
+            return z2m_device
+        # Z2M names a newly joined device by its IEEE hex by default; the rename
+        # step will correct this to the original ZHA name.
+        ieee_hex = f"0x{normalize_ieee(device.ieee)}"
+        console.print(
+            f"[yellow]Proceeding with fallback name:[/yellow] {ieee_hex}\n"
+            f"[dim]The rename step will set the correct name.[/dim]"
+        )
+        return {"ieee_address": ieee_hex, "friendly_name": ieee_hex}
     return None
 
 
@@ -504,7 +567,7 @@ async def step_reconcile_entity_ids(device: ZHADevice, ha_client: HAClient) -> N
 
 
 async def step_validate(device: ZHADevice, ha_client: HAClient, retries: int = 10) -> bool:
-    _print_step(6, "Validate")
+    _print_step(7, "Validate")
 
     z2m_device_id = await _wait_for_z2m_device_in_ha(device, ha_client)
     if z2m_device_id is None:
@@ -688,9 +751,10 @@ async def step_show_test_checklist(device: ZHADevice, ha_client: HAClient) -> No
 async def step_show_inspect_summary(device: ZHADevice, ha_client: HAClient) -> None:
     """Show current entities and dashboard cards for the migrated Z2M device.
 
-    Called after entity ID reconciliation (step 5) and before validation (step 6)
+    Called after entity ID reconciliation (step 5) and before validation (step 7)
     so the user can see which dashboard cards reference the device's entities.
     """
+    _print_step(6, "Review entities & dashboards")
     from zigporter.commands.inspect import show_migrate_inspect_summary  # noqa: PLC0415
 
     try:
@@ -785,14 +849,15 @@ async def run_wizard(
 
     console.print(
         "\nThis wizard will migrate [bold]{name}[/bold] from ZHA to Zigbee2MQTT "
-        "in 6 steps:\n"
+        "in 7 steps:\n"
         "\n"
         "  [cyan]1[/cyan]  Remove from ZHA    Unpair the device from ZHA [red](cannot be undone)[/red]\n"
         "  [cyan]2[/cyan]  Reset device       Factory-reset to clear the old ZHA pairing\n"
         "  [cyan]3[/cyan]  Pair with Z2M      Put device in pairing mode and join Zigbee2MQTT\n"
         "  [cyan]4[/cyan]  Rename             Restore original name and area in Z2M\n"
         "  [cyan]5[/cyan]  Restore entity IDs Rename IEEE-hex entity IDs back to friendly names\n"
-        "  [cyan]6[/cyan]  Validate           Confirm entities come back online\n"
+        "  [cyan]6[/cyan]  Review             Inspect entities and dashboard cards\n"
+        "  [cyan]7[/cyan]  Validate           Confirm entities come back online\n"
         "\n"
         "[dim]You can abort safely at step 1. After that, the device must complete\n"
         "pairing with Z2M before it can be used again.[/dim]".format(name=device.name)

--- a/src/zigporter/z2m_client.py
+++ b/src/zigporter/z2m_client.py
@@ -178,7 +178,7 @@ class Z2MClient:
         """Return the full Z2M device list."""
         try:
             return await self._get("/api/devices")
-        except RuntimeError:
+        except (RuntimeError, httpx.HTTPStatusError, httpx.RequestError):
             return await self._get_devices_via_ha()
 
     async def get_device_by_ieee(self, ieee: str) -> dict[str, Any] | None:

--- a/tests/commands/test_migrate.py
+++ b/tests/commands/test_migrate.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from zigporter.commands.migrate import (
+    step_pair_with_z2m,
     step_reconcile_entity_ids,
     step_remove_from_zha,
     step_rename,
@@ -674,3 +675,72 @@ async def test_step_show_inspect_summary_swallows_exceptions(sample_device, mock
 
     # Must not raise
     await step_show_inspect_summary(sample_device, mock_ha_client)
+
+
+# ---------------------------------------------------------------------------
+# step_pair_with_z2m
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pair_device() -> ZHADevice:
+    return ZHADevice(
+        device_id="dev-pair",
+        ieee="c4:d8:c8:ff:fe:3e:e5:cf",
+        name="Hallway Dimmer",
+        manufacturer="IKEA",
+        model="E2201",
+        device_type="EndDevice",
+        entities=[],
+    )
+
+
+async def test_step_pair_detects_correct_device(pair_device, mock_z2m_client):
+    """When the expected device joins Z2M it is returned and permit join is closed."""
+    z2m_entry = {"ieee_address": "0xc4d8c8fffe3ee5cf", "friendly_name": "0xc4d8c8fffe3ee5cf"}
+    # First call (pre-snapshot) returns empty; second (first poll) returns the device.
+    mock_z2m_client.get_devices = AsyncMock(side_effect=[[], [z2m_entry]])
+
+    with patch("questionary.select"), patch("questionary.confirm"):
+        result = await step_pair_with_z2m(pair_device, mock_z2m_client, timeout=10)
+
+    assert result is not None
+    assert result["ieee_address"] == "0xc4d8c8fffe3ee5cf"
+    mock_z2m_client.disable_permit_join.assert_called_once()
+
+
+async def test_step_pair_warns_on_wrong_device(pair_device, mock_z2m_client, capsys):
+    """When an unexpected device joins, a warning is printed and polling continues."""
+    wrong_device = {"ieee_address": "0xd44867fffe150421", "friendly_name": "0xd44867fffe150421"}
+    correct_device = {"ieee_address": "0xc4d8c8fffe3ee5cf", "friendly_name": "Hallway Dimmer"}
+
+    # Call 0: pre-snapshot (empty), Call 1: wrong device joined, Call 2: correct device joined
+    mock_z2m_client.get_devices = AsyncMock(
+        side_effect=[[], [wrong_device], [wrong_device, correct_device]]
+    )
+
+    with patch("questionary.select"), patch("questionary.confirm"):
+        result = await step_pair_with_z2m(pair_device, mock_z2m_client, timeout=20)
+
+    captured = capsys.readouterr()
+    assert "different device joined Z2M" in captured.out
+    assert "0xd44867fffe150421" in captured.out
+    assert result is not None
+    assert result["ieee_address"] == "0xc4d8c8fffe3ee5cf"
+
+
+async def test_step_pair_force_continue_constructs_fallback(pair_device, mock_z2m_client):
+    """Force-continue with device still not found returns an IEEE-based fallback entry."""
+    # Pre-snapshot returns empty; all polls also return empty — device never appears.
+    mock_z2m_client.get_devices = AsyncMock(return_value=[])
+
+    with (
+        patch("questionary.select") as mock_select,
+        patch("zigporter.commands.migrate.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="force")
+        result = await step_pair_with_z2m(pair_device, mock_z2m_client, timeout=1)
+
+    assert result is not None
+    assert result["ieee_address"] == "0xc4d8c8fffe3ee5cf"
+    assert result["friendly_name"] == "0xc4d8c8fffe3ee5cf"

--- a/tests/test_z2m_client.py
+++ b/tests/test_z2m_client.py
@@ -175,6 +175,51 @@ async def test_get_devices_falls_back_to_ha_registry_when_session_fails(client, 
     assert result[0]["definition"]["vendor"] == "IKEA"
 
 
+@respx.mock
+async def test_get_devices_falls_back_to_ha_registry_on_http_error(client, respx_mock):
+    """Non-RuntimeError HTTP errors (e.g. 503) also trigger the HA registry fallback."""
+    # Bearer returns a 503 — httpx.HTTPStatusError should be caught and trigger fallback
+    respx.get(f"{Z2M_URL}/api/devices").mock(
+        side_effect=[
+            httpx.Response(200, content=b"<html/>", headers={"content-type": "text/html"}),
+            httpx.Response(503),
+        ]
+    )
+    respx.post(INGRESS_SESSION_URL).mock(
+        return_value=httpx.Response(200, json={"data": {"session": SESSION}})
+    )
+
+    registry_entry = {
+        "id": "dev1",
+        "name": "Porch Sensor",
+        "name_by_user": None,
+        "manufacturer": "Sonoff",
+        "model": "SNZB-03",
+        "identifiers": [["mqtt", "zigbee2mqtt_0x1122334455667788"]],
+        "area_id": None,
+    }
+
+    from unittest.mock import AsyncMock, patch
+
+    ws_messages = iter(
+        [
+            json.dumps({"type": "auth_required"}),
+            json.dumps({"type": "auth_ok"}),
+            json.dumps({"id": 1, "type": "result", "success": True, "result": [registry_entry]}),
+        ]
+    )
+    mock_ws = AsyncMock()
+    mock_ws.recv = AsyncMock(side_effect=ws_messages)
+    mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+    mock_ws.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("websockets.connect", return_value=mock_ws):
+        result = await client.get_devices()
+
+    assert len(result) == 1
+    assert result[0]["ieee_address"] == "0x1122334455667788"
+
+
 # ---------------------------------------------------------------------------
 # permit_join and rename
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Wrong-device detection**: snapshots the Z2M device list before permit join opens and warns immediately if a different device joins (different IEEE than the one being migrated). This directly addresses a user error where the wrong remote was put in pairing mode — Z2M showed green interview but the CLI kept waiting silently.
- **Force-continue option at timeout**: replaces the binary "Retry pairing?" prompt with a 3-choice menu — Retry, Force continue (for when the device is visibly in Z2M but auto-detection failed), and Mark as failed. Force continue does a final API attempt then falls back to an IEEE-hex placeholder so rename/validate can still run.
- **Broader HTTP error handling in `get_devices`**: `httpx.HTTPStatusError` and `httpx.RequestError` now trigger the HA-registry fallback in addition to `RuntimeError`, preventing transient HTTP errors from crashing the polling loop.
- **Fix 7-step wizard (closes gap from PR #13)**: `WIZARD_STEPS` updated to 7, `step_show_inspect_summary` now calls `_print_step(6, "Review entities & dashboards")`, `step_validate` renumbered to step 7, and the intro text updated to list all 7 steps.

## Test plan

- [ ] Run `uv run pytest` — all 48 tests pass
- [ ] Start a migration and trigger the wrong device to pair — confirm the `⚠ A different device joined Z2M` warning appears immediately
- [ ] Let a pairing attempt time out — confirm the 3-choice menu appears with Retry / Force continue / Mark as failed
- [ ] Select "Force continue" — confirm the wizard proceeds to the rename step with the IEEE-hex fallback name
- [ ] Run a full migration — confirm the wizard shows `[1/7]` through `[7/7]` including the new Review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)