### PR TITLE
feat: z2m health command — LQI, battery, last-seen report

### DIFF
--- a/src/zigporter/commands/z2m_health.py
+++ b/src/zigporter/commands/z2m_health.py
@@ -1,0 +1,245 @@
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from typing import Any
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.table import Table
+
+from zigporter.z2m_client import Z2MClient
+
+console = Console()
+
+
+class SortField(str, Enum):
+    lqi = "lqi"
+    battery = "battery"
+    last_seen = "last-seen"
+
+
+def _parse_last_seen(value: Any) -> datetime | None:
+    """Parse Z2M last_seen into a timezone-aware datetime.
+
+    Z2M can emit last_seen as:
+    - An integer (milliseconds since epoch, when last_seen: ISO_8601_local)
+    - An ISO 8601 string (when last_seen: ISO_8601_local or ISO_8601_UTC)
+    - None / "N/A" / missing when disabled
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value / 1000, tz=UTC)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        if value in ("N/A", ""):
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _format_relative(dt: datetime | None, now: datetime) -> str:
+    if dt is None:
+        return "—"
+    delta = now - dt
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 0:
+        return "just now"
+    if total_seconds < 120:
+        return f"{total_seconds}s ago"
+    if total_seconds < 7200:
+        return f"{total_seconds // 60}m ago"
+    if total_seconds < 86400:
+        return f"{total_seconds // 3600}h ago"
+    return f"{delta.days}d ago"
+
+
+def _extract_health(device: dict[str, Any]) -> tuple[int | None, int | None, datetime | None]:
+    """Extract (lqi, battery_pct, last_seen_dt) from a Z2M device record."""
+    state: dict[str, Any] = device.get("state") or {}
+
+    lqi_raw = device.get("linkquality")
+    if lqi_raw is None:
+        lqi_raw = state.get("linkquality")
+    lqi = int(lqi_raw) if lqi_raw is not None else None
+
+    battery_raw = state.get("battery")
+    if battery_raw is None:
+        battery_raw = device.get("battery")
+    battery = int(battery_raw) if battery_raw is not None else None
+
+    last_seen_dt = _parse_last_seen(device.get("last_seen"))
+    return lqi, battery, last_seen_dt
+
+
+def _row_sort_key(
+    row: dict[str, Any],
+    sort: SortField | None,
+) -> tuple:
+    if sort == SortField.lqi:
+        lqi = row["lqi"]
+        return (lqi is None, lqi if lqi is not None else 0)
+    if sort == SortField.battery:
+        bat = row["battery"]
+        return (bat is None, bat if bat is not None else 0)
+    if sort == SortField.last_seen:
+        dt = row["last_seen_dt"]
+        return (dt is None, dt or datetime.min.replace(tzinfo=UTC))
+    # Default: OFFLINE → WARN → OK, then LQI ascending within each group
+    status_order = {"OFFLINE": 0, "WARN": 1, "OK": 2}
+    lqi = row["lqi"]
+    return (status_order.get(row["status"], 3), lqi if lqi is not None else 999)
+
+
+async def run_z2m_health(
+    ha_url: str,
+    token: str,
+    z2m_url: str,
+    verify_ssl: bool,
+    mqtt_topic: str,
+    sort: SortField | None,
+    warn_battery: int,
+    warn_lqi: int,
+    offline_after: int,
+    output_format: str,
+) -> bool:
+    """Fetch Z2M device health and render a report.
+
+    Returns True if there are no warnings and no offline devices.
+    """
+    client = Z2MClient(ha_url, token, z2m_url, verify_ssl, mqtt_topic)
+
+    with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as progress:
+        t = progress.add_task("Fetching Z2M device health...", total=None)
+        devices = await client.get_devices()
+        progress.update(t, description="Done")
+
+    devices = [d for d in devices if d.get("type") != "Coordinator"]
+
+    now = datetime.now(tz=UTC)
+    offline_delta = timedelta(minutes=offline_after)
+
+    rows: list[dict[str, Any]] = []
+    for d in devices:
+        lqi, battery, last_seen_dt = _extract_health(d)
+        name = d.get("friendly_name") or d.get("ieee_address") or "unknown"
+
+        is_offline = last_seen_dt is not None and (now - last_seen_dt) > offline_delta
+        has_low_battery = battery is not None and battery < warn_battery
+        has_low_lqi = lqi is not None and lqi < warn_lqi
+
+        if is_offline:
+            status = "OFFLINE"
+        elif has_low_battery or has_low_lqi:
+            status = "WARN"
+        else:
+            status = "OK"
+
+        rows.append(
+            {
+                "name": name,
+                "lqi": lqi,
+                "battery": battery,
+                "last_seen_dt": last_seen_dt,
+                "last_seen_rel": _format_relative(last_seen_dt, now),
+                "status": status,
+            }
+        )
+
+    rows.sort(key=lambda r: _row_sort_key(r, sort))
+
+    n_warn = sum(1 for r in rows if r["status"] == "WARN")
+    n_offline = sum(1 for r in rows if r["status"] == "OFFLINE")
+    healthy = n_warn == 0 and n_offline == 0
+
+    if output_format == "json":
+        payload = [
+            {
+                "name": r["name"],
+                "lqi": r["lqi"],
+                "battery": r["battery"],
+                "last_seen": r["last_seen_dt"].isoformat() if r["last_seen_dt"] else None,
+                "status": r["status"],
+            }
+            for r in rows
+        ]
+        console.print(json.dumps(payload, indent=2))
+        return healthy
+
+    _render_table(rows, n_warn, n_offline)
+    return healthy
+
+
+def _render_table(rows: list[dict[str, Any]], n_warn: int, n_offline: int) -> None:
+    console.rule("[bold cyan]Z2M NETWORK HEALTH[/bold cyan]")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Device", no_wrap=True)
+    table.add_column("LQI", justify="right")
+    table.add_column("Battery", justify="right")
+    table.add_column("Last Seen")
+    table.add_column("Status")
+
+    for r in rows:
+        lqi_str = str(r["lqi"]) if r["lqi"] is not None else "—"
+        battery_str = f"{r['battery']}%" if r["battery"] is not None else "—"
+
+        status = r["status"]
+        if status == "OK":
+            status_str = "[green]OK[/green]"
+            row_style = ""
+        elif status == "WARN":
+            status_str = "[yellow]⚠ WARN[/yellow]"
+            row_style = ""
+        else:
+            status_str = "[red]✗ OFFLINE[/red]"
+            row_style = "dim"
+
+        table.add_row(
+            r["name"], lqi_str, battery_str, r["last_seen_rel"], status_str, style=row_style
+        )
+
+    console.print(table)
+
+    summary_parts = [f"[bold]{len(rows)}[/bold] device(s)"]
+    if n_warn:
+        summary_parts.append(f"[yellow]{n_warn} warning(s)[/yellow]")
+    if n_offline:
+        summary_parts.append(f"[red]{n_offline} offline[/red]")
+    if not n_warn and not n_offline:
+        summary_parts.append("[green]all healthy[/green]")
+    console.print(" — ".join(summary_parts))
+
+
+def z2m_health_command(
+    ha_url: str,
+    token: str,
+    z2m_url: str,
+    verify_ssl: bool,
+    mqtt_topic: str,
+    sort: SortField | None = None,
+    warn_battery: int = 10,
+    warn_lqi: int = 50,
+    offline_after: int = 60,
+    output_format: str = "table",
+) -> bool:
+    return asyncio.run(
+        run_z2m_health(
+            ha_url=ha_url,
+            token=token,
+            z2m_url=z2m_url,
+            verify_ssl=verify_ssl,
+            mqtt_topic=mqtt_topic,
+            sort=sort,
+            warn_battery=warn_battery,
+            warn_lqi=warn_lqi,
+            offline_after=offline_after,
+            output_format=output_format,
+        )
+    )

--- a/src/zigporter/main.py
+++ b/src/zigporter/main.py
@@ -25,6 +25,14 @@ app = typer.Typer(
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+
+z2m_app = typer.Typer(
+    name="z2m",
+    help="Zigbee2MQTT network utilities.",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+app.add_typer(z2m_app, name="z2m")
 console = Console()
 
 _STYLE = questionary.Style(
@@ -367,6 +375,82 @@ def rename_device(
         new_name=new_name,
         apply=apply,
     )
+
+
+z2m_app = typer.Typer(
+    name="z2m",
+    help="Zigbee2MQTT network utilities.",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+app.add_typer(z2m_app, name="z2m")
+
+
+@z2m_app.command("health")
+def z2m_health(
+    sort: str = typer.Option(
+        None,
+        "--sort",
+        help="Sort field: lqi, battery, last-seen (default: offline first, then LQI ascending).",
+    ),
+    warn_battery: int = typer.Option(
+        10,
+        "--warn-battery",
+        help="Battery percentage below which a device is flagged as WARN.",
+    ),
+    warn_lqi: int = typer.Option(
+        50,
+        "--warn-lqi",
+        help="LQI value below which a device is flagged as WARN.",
+    ),
+    offline_after: int = typer.Option(
+        60,
+        "--offline-after",
+        help="Minutes since last-seen after which a device is considered OFFLINE.",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--format",
+        help="Output format: table, json.",
+    ),
+) -> None:
+    """Show LQI, battery, and last-seen for all Z2M devices and flag unhealthy ones.
+
+    Exits with a non-zero status code when any device is OFFLINE or WARN,
+    making it suitable for use in monitoring scripts.
+    """
+    from zigporter.commands.z2m_health import SortField, z2m_health_command  # noqa: PLC0415
+
+    ha_url, token, verify_ssl = _get_config()
+    z2m_url, mqtt_topic = _get_z2m_config()
+
+    sort_field: SortField | None = None
+    if sort is not None:
+        try:
+            sort_field = SortField(sort)
+        except ValueError:
+            valid = ", ".join(f.value for f in SortField)
+            console.print(f"[red]Invalid --sort value '{sort}'. Choose from: {valid}[/red]")
+            raise typer.Exit(code=1)
+
+    if output_format not in ("table", "json"):
+        console.print("[red]Invalid --format value. Choose from: table, json[/red]")
+        raise typer.Exit(code=1)
+
+    healthy = z2m_health_command(
+        ha_url=ha_url,
+        token=token,
+        z2m_url=z2m_url,
+        verify_ssl=verify_ssl,
+        mqtt_topic=mqtt_topic,
+        sort=sort_field,
+        warn_battery=warn_battery,
+        warn_lqi=warn_lqi,
+        offline_after=offline_after,
+        output_format=output_format,
+    )
+    if not healthy:
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/tests/commands/test_z2m_health.py
+++ b/tests/commands/test_z2m_health.py
@@ -1,0 +1,363 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+from zigporter.commands.z2m_health import (
+    SortField,
+    _extract_health,
+    _format_relative,
+    _parse_last_seen,
+    _row_sort_key,
+    run_z2m_health,
+)
+
+
+HA_URL = "https://ha.test"
+TOKEN = "test-token"
+Z2M_URL = "https://z2m.test"
+
+NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# _parse_last_seen
+# ---------------------------------------------------------------------------
+
+
+def test_parse_last_seen_none():
+    assert _parse_last_seen(None) is None
+
+
+def test_parse_last_seen_na_string():
+    assert _parse_last_seen("N/A") is None
+
+
+def test_parse_last_seen_empty_string():
+    assert _parse_last_seen("") is None
+
+
+def test_parse_last_seen_ms_integer():
+    result = _parse_last_seen(1717243200000)  # 2024-06-01T12:00:00Z
+    assert result is not None
+    assert result.tzinfo is UTC
+    assert result.year == 2024
+
+
+def test_parse_last_seen_iso_string_utc():
+    result = _parse_last_seen("2024-06-01T12:00:00Z")
+    assert result is not None
+    assert result.year == 2024
+    assert result.month == 6
+
+
+def test_parse_last_seen_iso_string_with_offset():
+    result = _parse_last_seen("2024-06-01T14:00:00+02:00")
+    assert result is not None
+    assert result.year == 2024
+
+
+def test_parse_last_seen_invalid_string():
+    assert _parse_last_seen("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# _format_relative
+# ---------------------------------------------------------------------------
+
+
+def test_format_relative_none():
+    assert _format_relative(None, NOW) == "—"
+
+
+def test_format_relative_seconds():
+    dt = NOW - timedelta(seconds=30)
+    assert _format_relative(dt, NOW) == "30s ago"
+
+
+def test_format_relative_minutes():
+    dt = NOW - timedelta(minutes=45)
+    result = _format_relative(dt, NOW)
+    assert result == "45m ago"
+
+
+def test_format_relative_hours():
+    dt = NOW - timedelta(hours=3)
+    result = _format_relative(dt, NOW)
+    assert result == "3h ago"
+
+
+def test_format_relative_days():
+    dt = NOW - timedelta(days=3)
+    result = _format_relative(dt, NOW)
+    assert result == "3d ago"
+
+
+def test_format_relative_future():
+    dt = NOW + timedelta(seconds=10)
+    assert _format_relative(dt, NOW) == "just now"
+
+
+# ---------------------------------------------------------------------------
+# _extract_health
+# ---------------------------------------------------------------------------
+
+
+def test_extract_health_top_level_fields():
+    device = {
+        "linkquality": 200,
+        "battery": 85,
+        "last_seen": "2024-06-01T11:55:00Z",
+    }
+    lqi, battery, last_seen_dt = _extract_health(device)
+    assert lqi == 200
+    assert battery == 85
+    assert last_seen_dt is not None
+
+
+def test_extract_health_state_nested():
+    device = {
+        "state": {"linkquality": 150, "battery": 42},
+        "last_seen": 1717243200000,
+    }
+    lqi, battery, _ = _extract_health(device)
+    assert lqi == 150
+    assert battery == 42
+
+
+def test_extract_health_all_missing():
+    lqi, battery, last_seen_dt = _extract_health({})
+    assert lqi is None
+    assert battery is None
+    assert last_seen_dt is None
+
+
+# ---------------------------------------------------------------------------
+# _row_sort_key
+# ---------------------------------------------------------------------------
+
+
+def _make_row(status: str, lqi: int | None, battery: int | None, dt: datetime | None) -> dict:
+    return {"status": status, "lqi": lqi, "battery": battery, "last_seen_dt": dt}
+
+
+def test_sort_key_lqi_none_last():
+    row_with = _make_row("OK", 100, 50, None)
+    row_without = _make_row("OK", None, 50, None)
+    key_with = _row_sort_key(row_with, SortField.lqi)
+    key_without = _row_sort_key(row_without, SortField.lqi)
+    assert key_with < key_without
+
+
+def test_sort_key_battery_ascending():
+    row_low = _make_row("WARN", 200, 5, None)
+    row_high = _make_row("OK", 200, 90, None)
+    assert _row_sort_key(row_low, SortField.battery) < _row_sort_key(row_high, SortField.battery)
+
+
+def test_sort_key_default_offline_first():
+    offline = _make_row("OFFLINE", 50, 80, None)
+    warn = _make_row("WARN", 50, 5, None)
+    ok = _make_row("OK", 200, 80, None)
+    assert _row_sort_key(offline, None) < _row_sort_key(warn, None)
+    assert _row_sort_key(warn, None) < _row_sort_key(ok, None)
+
+
+# ---------------------------------------------------------------------------
+# run_z2m_health — integration
+# ---------------------------------------------------------------------------
+
+
+def _now_minus(minutes: int) -> str:
+    return (datetime.now(tz=UTC) - timedelta(minutes=minutes)).isoformat()
+
+
+_HEALTHY_DEVICE = {
+    "friendly_name": "Kitchen Plug",
+    "ieee_address": "0x001122334455",
+    "type": "EndDevice",
+    "linkquality": 200,
+    "state": {"battery": 90},
+    "last_seen": _now_minus(2),
+}
+
+_WARN_DEVICE = {
+    "friendly_name": "Bedroom Door Sensor",
+    "ieee_address": "0x00aabbccddee",
+    "type": "EndDevice",
+    "linkquality": 30,
+    "state": {"battery": 5},
+    "last_seen": _now_minus(30),
+}
+
+_OFFLINE_DEVICE = {
+    "friendly_name": "Hallway Temp",
+    "ieee_address": "0x001234567890",
+    "type": "EndDevice",
+    "linkquality": 100,
+    "state": {"battery": 80},
+    "last_seen": _now_minus(60 * 24 * 3),  # 3 days ago
+}
+
+_COORDINATOR = {
+    "friendly_name": "Coordinator",
+    "ieee_address": "0x0000000000000000",
+    "type": "Coordinator",
+}
+
+
+async def _run(devices: list, **kwargs) -> bool:
+    defaults = dict(
+        ha_url=HA_URL,
+        token=TOKEN,
+        z2m_url=Z2M_URL,
+        verify_ssl=False,
+        mqtt_topic="zigbee2mqtt",
+        sort=None,
+        warn_battery=10,
+        warn_lqi=50,
+        offline_after=60,
+        output_format="table",
+    )
+    defaults.update(kwargs)
+    mock_client = AsyncMock()
+    mock_client.get_devices = AsyncMock(return_value=devices)
+    with patch("zigporter.commands.z2m_health.Z2MClient", return_value=mock_client):
+        with patch("zigporter.commands.z2m_health.console"):
+            with patch("zigporter.commands.z2m_health.Progress") as mock_progress_cls:
+                mock_progress = MagicMock()
+                mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+                mock_progress.__exit__ = MagicMock(return_value=False)
+                mock_progress_cls.return_value = mock_progress
+                return await run_z2m_health(**defaults)
+
+
+async def test_healthy_devices_returns_true():
+    result = await _run([_HEALTHY_DEVICE])
+    assert result is True
+
+
+async def test_warn_device_returns_false():
+    result = await _run([_WARN_DEVICE])
+    assert result is False
+
+
+async def test_offline_device_returns_false():
+    result = await _run([_OFFLINE_DEVICE])
+    assert result is False
+
+
+async def test_coordinator_excluded():
+    mock_client = AsyncMock()
+    mock_client.get_devices = AsyncMock(return_value=[_COORDINATOR, _HEALTHY_DEVICE])
+    with patch("zigporter.commands.z2m_health.Z2MClient", return_value=mock_client):
+        with patch("zigporter.commands.z2m_health.console"):
+            with patch("zigporter.commands.z2m_health.Progress") as mock_progress_cls:
+                mock_progress = MagicMock()
+                mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+                mock_progress.__exit__ = MagicMock(return_value=False)
+                mock_progress_cls.return_value = mock_progress
+                result = await run_z2m_health(
+                    ha_url=HA_URL,
+                    token=TOKEN,
+                    z2m_url=Z2M_URL,
+                    verify_ssl=False,
+                    mqtt_topic="zigbee2mqtt",
+                    sort=None,
+                    warn_battery=10,
+                    warn_lqi=50,
+                    offline_after=60,
+                    output_format="table",
+                )
+    assert result is True
+
+
+async def test_json_output_returns_correct_keys():
+    import json as _json
+
+    captured: list[str] = []
+
+    def fake_print(content, *args, **kwargs):
+        captured.append(str(content))
+
+    mock_client = AsyncMock()
+    mock_client.get_devices = AsyncMock(return_value=[_HEALTHY_DEVICE])
+    with patch("zigporter.commands.z2m_health.Z2MClient", return_value=mock_client):
+        with patch("zigporter.commands.z2m_health.console") as mock_console:
+            mock_console.print.side_effect = fake_print
+            with patch("zigporter.commands.z2m_health.Progress") as mock_progress_cls:
+                mock_progress = MagicMock()
+                mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+                mock_progress.__exit__ = MagicMock(return_value=False)
+                mock_progress_cls.return_value = mock_progress
+                await run_z2m_health(
+                    ha_url=HA_URL,
+                    token=TOKEN,
+                    z2m_url=Z2M_URL,
+                    verify_ssl=False,
+                    mqtt_topic="zigbee2mqtt",
+                    sort=None,
+                    warn_battery=10,
+                    warn_lqi=50,
+                    offline_after=60,
+                    output_format="json",
+                )
+
+    assert len(captured) == 1
+    parsed = _json.loads(captured[0])
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+    assert "name" in parsed[0]
+    assert "lqi" in parsed[0]
+    assert "battery" in parsed[0]
+    assert "last_seen" in parsed[0]
+    assert "status" in parsed[0]
+
+
+async def test_no_devices_returns_true():
+    result = await _run([])
+    assert result is True
+
+
+async def test_custom_warn_battery_threshold():
+    device = dict(_HEALTHY_DEVICE)
+    device = {**device, "state": {"battery": 25}}
+    # Default warn_battery=10, device at 25% → OK
+    assert await _run([device], warn_battery=10) is True
+    # With warn_battery=30, device at 25% → WARN
+    assert await _run([device], warn_battery=30) is False
+
+
+async def test_custom_warn_lqi_threshold():
+    device = {**_HEALTHY_DEVICE, "linkquality": 60}
+    # Default warn_lqi=50, device at 60 → OK
+    assert await _run([device], warn_lqi=50) is True
+    # With warn_lqi=80, device at 60 → WARN
+    assert await _run([device], warn_lqi=80) is False
+
+
+async def test_sort_by_lqi():
+    """Sorting by LQI ascending should not raise and should return a result."""
+    result = await _run([_HEALTHY_DEVICE, _WARN_DEVICE], sort=SortField.lqi)
+    assert result is False  # _WARN_DEVICE has lqi=30 < threshold=50
+
+
+async def test_sort_by_battery():
+    result = await _run([_HEALTHY_DEVICE, _WARN_DEVICE], sort=SortField.battery)
+    assert result is False
+
+
+async def test_offline_after_custom_threshold():
+    # Device last seen 90 minutes ago
+    past = datetime.now(tz=UTC) - timedelta(minutes=90)
+    device = {
+        "friendly_name": "Old Device",
+        "ieee_address": "0x001122",
+        "type": "EndDevice",
+        "linkquality": 200,
+        "state": {"battery": 80},
+        "last_seen": past.isoformat(),
+    }
+    # With offline_after=60 (default), 90m → OFFLINE
+    assert await _run([device], offline_after=60) is False
+    # With offline_after=120, 90m is still OK
+    assert await _run([device], offline_after=120) is True


### PR DESCRIPTION
Closes #18

## Summary

- Adds `zigporter z2m health` command via a new `z2m` sub-app in Typer
- Fetches all Z2M devices and extracts LQI, battery %, and last-seen from the device records
- Renders a sorted, colour-coded table with OK / ⚠ WARN / ✗ OFFLINE status per device

## Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--sort lqi\|battery\|last-seen` | offline-first, then LQI asc | Sort field |
| `--warn-battery N` | 10 | Battery % threshold for WARN |
| `--warn-lqi N` | 50 | LQI threshold for WARN |
| `--offline-after N` | 60 | Minutes since last-seen to flag as OFFLINE |
| `--format table\|json` | table | Output format |

Exits with code 1 when any device is WARN or OFFLINE (scripting-friendly).

## Test plan

- [x] 30 new tests in `tests/commands/test_z2m_health.py`
- [x] Unit tests: `_parse_last_seen`, `_format_relative`, `_extract_health`, `_row_sort_key`
- [x] Integration tests: healthy/warn/offline classification, coordinator exclusion, JSON output, custom thresholds, sort modes
- [x] Full suite: 356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)