### PR TITLE
fix: handle lovelace strategy dashboards and save failures gracefully

### DIFF
--- a/src/zigporter/commands/rename.py
+++ b/src/zigporter/commands/rename.py
@@ -404,8 +404,13 @@ async def execute_rename(ha_client: HAClient, plan: RenamePlan) -> None:
             url_path = loc.item_id or None
             console.print(f"  Updating dashboard [dim]{loc.name!r}[/dim]...", end=" ")
             patched = _deep_replace(loc.raw_config, old, new)
-            await ha_client.save_lovelace_config(patched, url_path)
-            console.print("[green]✓[/green]")
+            try:
+                await ha_client.save_lovelace_config(patched, url_path)
+                console.print("[green]✓[/green]")
+            except RuntimeError:
+                console.print(
+                    "[yellow]⚠ skipped (dashboard is read-only — update manually)[/yellow]"
+                )
 
         elif loc.context == "config_entry":
             console.print(f"  Updating helper [dim]{loc.name!r}[/dim]...", end=" ")
@@ -937,7 +942,13 @@ async def execute_device_rename(
         elif context == "scene":
             await ha_client.update_scene(item_id, config)
         elif context == "lovelace":
-            await ha_client.save_lovelace_config(config, item_id or None)
+            try:
+                await ha_client.save_lovelace_config(config, item_id or None)
+            except RuntimeError:
+                console.print(
+                    "[yellow]⚠ skipped (dashboard is read-only — update manually)[/yellow]"
+                )
+                continue
         elif context == "config_entry":
             await ha_client.update_config_entry_options(item_id, config)
 

--- a/src/zigporter/ha_client.py
+++ b/src/zigporter/ha_client.py
@@ -217,6 +217,8 @@ class HAClient:
         try:
             result = await self._ws_command(cmd)
             if result is not None:
+                if "strategy" in result:
+                    return YAML_MODE  # auto-generated dashboard, cannot be saved via WS
                 return result
         except RuntimeError as exc:
             if "mode_not_storage" in str(exc) or "config_requires_reload" in str(exc):
@@ -232,7 +234,10 @@ class HAClient:
             ) as client:
                 resp = await client.get(f"{self._ha_url}/api/lovelace/config", params=params)
                 resp.raise_for_status()
-                return resp.json()
+                data = resp.json()
+                if "strategy" in data:
+                    return YAML_MODE  # auto-generated dashboard, cannot be saved via WS
+                return data
         except (httpx.HTTPError, ValueError, RuntimeError, OSError):
             return YAML_MODE if _yaml_mode else None
 

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -421,6 +421,35 @@ async def test_execute_rename_patches_lovelace_named(mock_exec_client):
     assert patched_url == "mobile"
 
 
+async def test_execute_rename_lovelace_save_failure_warns_and_continues(mock_exec_client, mocker):
+    """save_lovelace_config raises RuntimeError → warns and does not crash."""
+    mock_exec_client.save_lovelace_config = AsyncMock(
+        side_effect=RuntimeError("WebSocket command failed: Not supported")
+    )
+    printed = []
+    mocker.patch(
+        "zigporter.commands.rename.console.print",
+        side_effect=lambda *a, **kw: printed.append(a[0] if a else ""),
+    )
+    config = {"views": [{"entity": "switch.old"}]}
+    plan = RenamePlan(
+        old_entity_id="switch.old",
+        new_entity_id="switch.new",
+        locations=[
+            RenameLocation(
+                context="lovelace",
+                name="Lights",
+                item_id="lights",
+                occurrences=1,
+                raw_config=config,
+            )
+        ],
+    )
+    # Must not raise
+    await execute_rename(mock_exec_client, plan)
+    assert any("skipped" in str(p) for p in printed)
+
+
 # ---------------------------------------------------------------------------
 # display_plan (smoke test — must not raise)
 # ---------------------------------------------------------------------------
@@ -1606,6 +1635,54 @@ async def test_execute_device_rename_script_scene_lovelace_config_entry(mock_ful
     mock_full_exec_client.update_script.assert_called_once()
     mock_full_exec_client.update_scene.assert_called_once()
     mock_full_exec_client.save_lovelace_config.assert_called_once()
+    mock_full_exec_client.update_config_entry_options.assert_called_once()
+
+
+async def test_execute_device_rename_lovelace_save_failure_warns_and_continues(
+    mock_full_exec_client, mocker
+):
+    """save_lovelace_config raises RuntimeError → warns, does not crash, other updates continue."""
+    from zigporter.commands.rename import DeviceRenamePlan, execute_device_rename  # noqa: PLC0415
+
+    mock_full_exec_client.save_lovelace_config = AsyncMock(
+        side_effect=RuntimeError("WebSocket command failed: Not supported")
+    )
+    printed = []
+    mocker.patch(
+        "zigporter.commands.rename.console.print",
+        side_effect=lambda *a, **kw: printed.append(a[0] if a else ""),
+    )
+    plan = DeviceRenamePlan(
+        device_id="dev1",
+        old_device_name="Kitchen Plug",
+        new_device_name="Bedroom Lamp",
+        plans=[
+            RenamePlan(
+                old_entity_id="switch.kitchen_plug",
+                new_entity_id="switch.bedroom_lamp",
+                locations=[
+                    RenameLocation(
+                        context="lovelace",
+                        name="Lights",
+                        item_id="lights",
+                        occurrences=1,
+                        raw_config={"views": [{"entity": "switch.kitchen_plug"}]},
+                    ),
+                    RenameLocation(
+                        context="config_entry",
+                        name="Helper",
+                        item_id="ce1",
+                        occurrences=1,
+                        raw_config={"entity_id": "switch.kitchen_plug"},
+                    ),
+                ],
+            )
+        ],
+    )
+    # Must not raise
+    await execute_device_rename(mock_full_exec_client, plan)
+    assert any("skipped" in str(p) for p in printed)
+    # Other contexts still processed
     mock_full_exec_client.update_config_entry_options.assert_called_once()
 
 

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -589,6 +589,31 @@ async def test_get_lovelace_config_rest_fallback_with_url_path(client, mocker):
     assert result == lv_config
 
 
+@respx.mock
+async def test_get_lovelace_config_strategy_returns_yaml_mode(client, mocker):
+    """WS returns a strategy-based config → get_lovelace_config returns YAML_MODE."""
+    from zigporter.ha_client import is_yaml_mode  # noqa: PLC0415
+
+    mock_ws = _make_ws(mocker, {"strategy": {"type": "original-states"}})
+    mocker.patch("websockets.connect", return_value=mock_ws)
+    result = await client.get_lovelace_config()
+    assert is_yaml_mode(result)
+
+
+@respx.mock
+async def test_get_lovelace_config_rest_fallback_strategy_returns_yaml_mode(client, mocker):
+    """WS fails (non-yaml-mode error) → REST returns strategy config → YAML_MODE."""
+    from zigporter.ha_client import is_yaml_mode  # noqa: PLC0415
+
+    mock_ws = _make_ws_fail(mocker)
+    mocker.patch("websockets.connect", return_value=mock_ws)
+    respx.get(f"{HA_URL}/api/lovelace/config").mock(
+        return_value=httpx.Response(200, json={"strategy": {"type": "grid"}})
+    )
+    result = await client.get_lovelace_config()
+    assert is_yaml_mode(result)
+
+
 async def test_delete_entity(client, mocker):
     mock_ws = _make_ws(mocker, None)
     mocker.patch("websockets.connect", return_value=mock_ws)


### PR DESCRIPTION
## Problem

`zigporter rename-device` (and `rename-entity`) crashes with a `RuntimeError` when a Lovelace dashboard cannot be saved via `lovelace/config/save`:

```
RuntimeError: WebSocket command failed: {'id': 1, 'type': 'result', 'success': False,
  'error': {'code': 'error', 'message': 'Not supported'}}
```

The crash occurs **after** entity IDs have already been successfully renamed in the HA registry, leaving dashboards with stale entity references.

**Root cause:** HA returns "Not supported" for `lovelace/config/save` on *strategy-based dashboards* — dashboards with a top-level `"strategy"` key that auto-generate their layout (e.g. `{"strategy": {"type": "original-states"}}`). These dashboards can be fetched via `lovelace/config/get`, so they make it into the rename plan, but HA refuses to write them back.

## Fix

**Part 1 — Detect strategy dashboards upfront (`ha_client.py`):**
After fetching a Lovelace config, check for a top-level `"strategy"` key and return the existing `YAML_MODE` sentinel. This excludes strategy dashboards from the rename plan and reports them to the user alongside YAML-mode dashboards (both are auto-managed and cannot be saved via the API).

**Part 2 — Graceful error handling (`rename.py`):**
Wrap `save_lovelace_config` calls in `execute_rename` and `execute_device_rename` in `try/except`. Any unexpected save failure now prints `⚠ skipped (dashboard is read-only — update manually)` and continues, rather than crashing the entire operation.

## Tests

- `test_get_lovelace_config_strategy_returns_yaml_mode` — WS returns strategy config → `YAML_MODE`
- `test_get_lovelace_config_rest_fallback_strategy_returns_yaml_mode` — REST fallback returns strategy config → `YAML_MODE`
- `test_execute_rename_lovelace_save_failure_warns_and_continues` — save raises `RuntimeError` → warns, does not crash
- `test_execute_device_rename_lovelace_save_failure_warns_and_continues` — same for `execute_device_rename`

All 184 existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)