### PR TITLE
fix: handle YAML_MODE sentinel in inspect dashboard scan

### DIFF
--- a/src/zigporter/commands/inspect.py
+++ b/src/zigporter/commands/inspect.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from zigporter.entity_refs import collect_config_entity_ids
-from zigporter.ha_client import HAClient
+from zigporter.ha_client import HAClient, is_yaml_mode
 from zigporter.lovelace import cards_from_view as _cards_from_view
 from zigporter.lovelace import discover_dashboards
 from zigporter.ui import QUESTIONARY_STYLE
@@ -151,7 +151,7 @@ async def show_migrate_inspect_summary(
 
     dashboard_refs: list[DashboardRef] = []
     for url_path, config in zip(dashboard_url_paths, lovelace_configs, strict=True):
-        if config is None:
+        if config is None or is_yaml_mode(config):
             continue
         title = dashboard_titles.get(url_path, url_path or "Default")
         dashboard_refs.extend(_scan_dashboard(config, title, target))
@@ -222,7 +222,7 @@ def build_deps(
     # Lovelace dashboard refs
     dashboard_refs: list[DashboardRef] = []
     for url_path, config in all_data["lovelace"]:
-        if config is None:
+        if config is None or is_yaml_mode(config):
             continue
         title = all_data["dashboard_titles"].get(url_path, url_path or "Default")
         dashboard_refs.extend(_scan_dashboard(config, title, target))
@@ -405,6 +405,8 @@ def _debug_lovelace(all_data: dict[str, Any]) -> None:
         label = url_path or "Default"
         if config is None:
             console.print(f"  [red]✗[/red]  {label}  (fetch failed)")
+        elif is_yaml_mode(config):
+            console.print(f"  [yellow]~[/yellow]  {label}  (YAML mode — skipped)")
         else:
             views = config.get("views", [])
             card_count = sum(len(_cards_from_view(v)) for v in views)

--- a/tests/commands/test_inspect.py
+++ b/tests/commands/test_inspect.py
@@ -7,6 +7,7 @@ from zigporter.commands.inspect import (
     build_deps,
     show_report,
 )
+from zigporter.ha_client import YAML_MODE
 
 # ---------------------------------------------------------------------------
 # Lovelace walker
@@ -450,4 +451,92 @@ async def test_show_migrate_inspect_summary_discovers_extra_dashboards():
     await show_migrate_inspect_summary(["switch.kitchen_plug"], ha_client)
 
     # default (None) + "mobile"
+    assert ha_client.get_lovelace_config.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# YAML_MODE sentinel handling
+# ---------------------------------------------------------------------------
+
+
+def test_build_deps_yaml_mode_dashboard_does_not_raise():
+    """build_deps must not crash when a lovelace entry is the YAML_MODE sentinel."""
+    data = {
+        **_BASE_DATA,
+        "lovelace": [(None, YAML_MODE)],
+    }
+    deps = build_deps("00:11:22:33:44:55:66:77", data)
+    assert deps is not None
+    # YAML-mode dashboard is silently skipped — no dashboard refs
+    assert deps.dashboard_refs == []
+
+
+def test_build_deps_mixed_yaml_mode_and_real_dashboard():
+    """Only real configs are scanned; YAML_MODE entries are skipped."""
+    real_config = {
+        "views": [
+            {
+                "title": "Home",
+                "cards": [{"type": "entities", "entities": ["switch.kitchen_plug"]}],
+            }
+        ]
+    }
+    data = {
+        **_BASE_DATA,
+        "lovelace": [
+            ("yaml-dash", YAML_MODE),
+            ("real-dash", real_config),
+        ],
+        "dashboard_titles": {"yaml-dash": "YAML Dash", "real-dash": "Real Dash"},
+    }
+    deps = build_deps("00:11:22:33:44:55:66:77", data)
+    assert deps is not None
+    assert len(deps.dashboard_refs) == 1
+    assert deps.dashboard_refs[0].dashboard_title == "Real Dash"
+
+
+async def test_show_migrate_inspect_summary_yaml_mode_does_not_raise():
+    """show_migrate_inspect_summary must not crash when get_lovelace_config returns YAML_MODE."""
+    from unittest.mock import AsyncMock, MagicMock  # noqa: PLC0415
+
+    from zigporter.commands.inspect import show_migrate_inspect_summary  # noqa: PLC0415
+
+    ha_client = MagicMock()
+    ha_client.get_panels = AsyncMock(return_value={})
+    ha_client.get_lovelace_config = AsyncMock(return_value=YAML_MODE)
+
+    # Must not raise AttributeError: '_YamlMode' object has no attribute 'get'
+    await show_migrate_inspect_summary(["switch.kitchen_plug"], ha_client)
+
+    ha_client.get_lovelace_config.assert_called_once_with(None)
+
+
+async def test_show_migrate_inspect_summary_yaml_mode_skipped_multiple_dashboards():
+    """YAML_MODE dashboards are skipped; real ones are still scanned."""
+    from unittest.mock import AsyncMock, MagicMock  # noqa: PLC0415
+
+    from zigporter.commands.inspect import show_migrate_inspect_summary  # noqa: PLC0415
+
+    real_config = {
+        "views": [
+            {
+                "title": "Main",
+                "cards": [{"type": "entities", "entities": ["switch.kitchen_plug"]}],
+            }
+        ]
+    }
+
+    ha_client = MagicMock()
+    ha_client.get_panels = AsyncMock(
+        return_value={
+            "lovelace": {"component_name": "lovelace", "url_path": ""},
+            "mobile": {"component_name": "lovelace", "url_path": "mobile"},
+        }
+    )
+    # First call (default) returns YAML_MODE; second call (mobile) returns a real config
+    ha_client.get_lovelace_config = AsyncMock(side_effect=[YAML_MODE, real_config])
+
+    # Must not raise
+    await show_migrate_inspect_summary(["switch.kitchen_plug"], ha_client)
+
     assert ha_client.get_lovelace_config.call_count == 2


### PR DESCRIPTION
## Summary

- `inspect.py` guarded against `None` lovelace configs but not the `YAML_MODE` sentinel returned by `get_lovelace_config` when a dashboard is in YAML mode
- This caused `AttributeError: '_YamlMode' object has no attribute 'get'` in step 6 of the migrate wizard (`show_migrate_inspect_summary`) and in the `inspect` command (`build_deps`)
- Adds `is_yaml_mode(config)` checks alongside the existing `config is None` guards in all three affected code paths

## Test plan

- [x] `test_build_deps_yaml_mode_dashboard_does_not_raise` — `build_deps` with a YAML_MODE lovelace entry, no crash, empty `dashboard_refs`
- [x] `test_build_deps_mixed_yaml_mode_and_real_dashboard` — YAML_MODE entry skipped, real config alongside it still scanned
- [x] `test_show_migrate_inspect_summary_yaml_mode_does_not_raise` — reproduces the exact crash from migration step 6
- [x] `test_show_migrate_inspect_summary_yaml_mode_skipped_multiple_dashboards` — multiple dashboards, YAML_MODE one skipped, real one still processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)