### PR TITLE
feat(migrate): interactive area picker in step 4

### DIFF
--- a/src/zigporter/commands/migrate.py
+++ b/src/zigporter/commands/migrate.py
@@ -359,59 +359,113 @@ async def step_rename(
     z2m_client: Z2MClient,
     ha_client: HAClient,
 ) -> bool:
-    _print_step(4, "Rename device in Z2M")
+    _print_step(4, "Rename & area")
 
     current_name = z2m_device.get("friendly_name", "")
     target_name = device.name
+    renamed = True
 
     if current_name == target_name:
         console.print(f"[green]✓ Already named correctly:[/green] {target_name}")
-        return True
+    else:
+        console.print(f"\n  Z2M assigned:   [dim]{current_name}[/dim]")
+        console.print(f"  Will rename to: [bold]{target_name}[/bold]\n")
 
-    console.print(f"\n  Z2M assigned:   [dim]{current_name}[/dim]")
-    console.print(f"  Will rename to: [bold]{target_name}[/bold]\n")
+        console.print()
 
-    console.print()
+        confirm = await questionary.confirm(
+            f'Apply rename to "{target_name}"?', default=True, style=_STYLE
+        ).unsafe_ask_async()
+        if not confirm:
+            console.print("[yellow]Rename skipped.[/yellow]")
+            renamed = False
+        else:
+            try:
+                await z2m_client.rename_device(current_name, target_name)
+                console.print(f"[green]✓ Renamed to {target_name}[/green]")
+            except (RuntimeError, OSError) as exc:
+                console.print(f"[red]Rename failed: {exc}[/red]")
+                return False
 
-    confirm = await questionary.confirm(
-        f'Apply rename to "{target_name}"?', default=True, style=_STYLE
-    ).unsafe_ask_async()
-    if not confirm:
-        console.print("[yellow]Rename skipped.[/yellow]")
-        return False
+    await _step_assign_area(device, ha_client)
+    return renamed
 
-    try:
-        await z2m_client.rename_device(current_name, target_name)
-        console.print(f"[green]✓ Renamed to {target_name}[/green]")
-    except (RuntimeError, OSError) as exc:
-        console.print(f"[red]Rename failed: {exc}[/red]")
-        return False
 
-    # Set area in HA if device has one — must use the new Z2M device_id.
-    # Z2M may take a moment to register in HA after renaming, so we poll briefly.
-    if device.area_id:
-        z2m_device_id = await _wait_for_z2m_device_in_ha(device, ha_client, timeout=30)
-        if z2m_device_id:
-            for attempt in range(4):  # up to 4 attempts: 0, 3, 6, 9 s after rename
-                try:
-                    await ha_client.update_device_area(z2m_device_id, device.area_id)
-                    console.print(f"[green]✓ Area set to {device.area_name}[/green]")
-                    break
-                except (RuntimeError, OSError):
-                    if attempt < 3:
-                        await asyncio.sleep(3)
-            else:
-                console.print(
-                    f"[yellow]Note:[/yellow] Could not set area automatically. "
-                    f"Set [bold]{device.area_name}[/bold] manually in HA."
-                )
+async def _prompt_area(device: ZHADevice, areas: list[dict[str, Any]]) -> str | None:
+    """Show an area picker and return the chosen area_id, or None for no area."""
+    _NO_AREA = "__no_area__"
+
+    areas_sorted = sorted(areas, key=lambda a: a.get("name", "").lower())
+    original_area = next((a for a in areas_sorted if a.get("area_id") == device.area_id), None)
+
+    if device.area_name:
+        if original_area:
+            console.print(f"\n  Area (from ZHA): [bold]{device.area_name}[/bold]")
         else:
             console.print(
-                f"[yellow]Note:[/yellow] Z2M device not yet in HA registry. "
-                f"Set area [bold]{device.area_name}[/bold] manually in HA."
+                f"\n  Area (from ZHA): [dim]{device.area_name}[/dim] "
+                f"[yellow](no longer exists in HA)[/yellow]"
             )
+    else:
+        console.print("\n  No area was assigned in ZHA.")
 
-    return True
+    choices = [
+        questionary.Choice(title=a.get("name", a["area_id"]), value=a["area_id"])
+        for a in areas_sorted
+    ]
+    choices.append(questionary.Choice(title="── No area ──", value=_NO_AREA))
+
+    default_value = original_area["area_id"] if original_area else _NO_AREA
+
+    selected = await questionary.select(
+        "Assign area:",
+        choices=choices,
+        default=default_value,
+        style=_STYLE,
+    ).unsafe_ask_async()
+
+    return None if selected == _NO_AREA else selected
+
+
+async def _step_assign_area(device: ZHADevice, ha_client: HAClient) -> None:
+    """Prompt for area assignment and apply it to the Z2M device in HA."""
+    z2m_device_id = await _wait_for_z2m_device_in_ha(device, ha_client, timeout=30)
+    if not z2m_device_id:
+        console.print(
+            "[yellow]Note:[/yellow] Z2M device not yet in HA registry — area assignment skipped."
+        )
+        return
+
+    try:
+        areas = await ha_client.get_area_registry()
+    except (RuntimeError, OSError) as exc:
+        console.print(f"[yellow]Could not fetch area list: {exc}[/yellow]")
+        # Graceful fallback: silently restore original area
+        if device.area_id:
+            try:
+                await ha_client.update_device_area(z2m_device_id, device.area_id)
+                console.print(f"[green]✓ Area restored: {device.area_name}[/green]")
+            except (RuntimeError, OSError):
+                console.print(
+                    f"[yellow]Note:[/yellow] Could not set area. "
+                    f"Set [bold]{device.area_name}[/bold] manually in HA."
+                )
+        return
+
+    chosen_area_id = await _prompt_area(device, areas)
+
+    area_id_to_set = chosen_area_id or ""
+    try:
+        await ha_client.update_device_area(z2m_device_id, area_id_to_set)
+        if chosen_area_id:
+            area_name = next(
+                (a["name"] for a in areas if a.get("area_id") == chosen_area_id), chosen_area_id
+            )
+            console.print(f"[green]✓ Area set: {area_name}[/green]")
+        elif device.area_id:
+            console.print("[green]✓ Area cleared[/green]")
+    except (RuntimeError, OSError) as exc:
+        console.print(f"[yellow]Could not set area: {exc}[/yellow]")
 
 
 _IEEE_PATTERN = re.compile(r"0x[0-9a-fA-F]{16}")
@@ -866,7 +920,7 @@ async def run_wizard(
         "  [cyan]1[/cyan]  Remove from ZHA    Unpair the device from ZHA [red](cannot be undone)[/red]\n"
         "  [cyan]2[/cyan]  Reset device       Factory-reset to clear the old ZHA pairing\n"
         "  [cyan]3[/cyan]  Pair with Z2M      Put device in pairing mode and join Zigbee2MQTT\n"
-        "  [cyan]4[/cyan]  Rename             Restore original name and area in Z2M\n"
+        "  [cyan]4[/cyan]  Rename & area      Restore name and choose an area in HA\n"
         "  [cyan]5[/cyan]  Restore entity IDs Rename IEEE-hex entity IDs back to friendly names\n"
         "  [cyan]6[/cyan]  Review             Inspect entities and dashboard cards\n"
         "  [cyan]7[/cyan]  Validate           Confirm entities come back online\n"

--- a/tests/commands/test_migrate.py
+++ b/tests/commands/test_migrate.py
@@ -83,6 +83,12 @@ def mock_ha_client():
     client.get_scenes = AsyncMock(return_value=[])
     client.get_config_entries = AsyncMock(return_value=[])
     client.get_z2m_config_entry_id = AsyncMock(return_value=None)
+    client.get_area_registry = AsyncMock(
+        return_value=[
+            {"area_id": "kitchen", "name": "Kitchen"},
+            {"area_id": "living_room", "name": "Living Room"},
+        ]
+    )
     return client
 
 
@@ -150,7 +156,8 @@ async def test_step_remove_from_zha_falls_back_to_manual_on_error(sample_device,
 async def test_step_rename_skips_when_names_match(sample_device, mock_z2m_client, mock_ha_client):
     z2m_device = {"friendly_name": "Kitchen Plug"}
 
-    result = await step_rename(sample_device, z2m_device, mock_z2m_client, mock_ha_client)
+    with patch("zigporter.commands.migrate._step_assign_area", new_callable=AsyncMock):
+        result = await step_rename(sample_device, z2m_device, mock_z2m_client, mock_ha_client)
 
     assert result is True
     mock_z2m_client.rename_device.assert_not_called()
@@ -161,7 +168,10 @@ async def test_step_rename_applies_rename_on_confirm(
 ):
     z2m_device = {"friendly_name": "0xaabbccddeeff0011"}
 
-    with patch("questionary.confirm") as mock_confirm:
+    with (
+        patch("questionary.confirm") as mock_confirm,
+        patch("zigporter.commands.migrate._step_assign_area", new_callable=AsyncMock),
+    ):
         mock_confirm.return_value.unsafe_ask_async = AsyncMock(return_value=True)
         result = await step_rename(sample_device, z2m_device, mock_z2m_client, mock_ha_client)
 
@@ -172,12 +182,143 @@ async def test_step_rename_applies_rename_on_confirm(
 async def test_step_rename_skips_on_cancel(sample_device, mock_z2m_client, mock_ha_client):
     z2m_device = {"friendly_name": "0xaabbccddeeff0011"}
 
-    with patch("questionary.confirm") as mock_confirm:
+    with (
+        patch("questionary.confirm") as mock_confirm,
+        patch("zigporter.commands.migrate._step_assign_area", new_callable=AsyncMock),
+    ):
         mock_confirm.return_value.unsafe_ask_async = AsyncMock(return_value=False)
         result = await step_rename(sample_device, z2m_device, mock_z2m_client, mock_ha_client)
 
     assert result is False
     mock_z2m_client.rename_device.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _step_assign_area / _prompt_area
+# ---------------------------------------------------------------------------
+
+
+async def test_step_assign_area_keeps_original_area(sample_device, mock_ha_client):
+    """When the user picks the original area, update_device_area is called with that area."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="kitchen")
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _step_assign_area(sample_device, mock_ha_client)
+
+    mock_ha_client.update_device_area.assert_called_once_with("z2m-device-id", "kitchen")
+
+
+async def test_step_assign_area_changes_area(sample_device, mock_ha_client):
+    """When the user selects a different area, update_device_area is called with the new area."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="living_room")
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _step_assign_area(sample_device, mock_ha_client)
+
+    mock_ha_client.update_device_area.assert_called_once_with("z2m-device-id", "living_room")
+
+
+async def test_step_assign_area_no_area_device_assigns_area(mock_ha_client):
+    """Device with no ZHA area: user can pick an area and it is applied."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    device_no_area = ZHADevice(
+        device_id="dev-x",
+        ieee="00:11:22:33:44:55:66:88",
+        name="Hallway Motion",
+        device_type="EndDevice",
+        entities=[],
+    )
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="living_room")
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _step_assign_area(device_no_area, mock_ha_client)
+
+    mock_ha_client.update_device_area.assert_called_once_with("z2m-device-id", "living_room")
+
+
+async def test_step_assign_area_clears_area(sample_device, mock_ha_client):
+    """When the user selects 'No area', update_device_area is called with an empty string."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="__no_area__")
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _step_assign_area(sample_device, mock_ha_client)
+
+    mock_ha_client.update_device_area.assert_called_once_with("z2m-device-id", "")
+
+
+async def test_step_assign_area_registry_fetch_fails_restores_original(
+    sample_device, mock_ha_client
+):
+    """When get_area_registry raises, the original ZHA area is restored silently."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    mock_ha_client.get_area_registry = AsyncMock(side_effect=RuntimeError("WS error"))
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await _step_assign_area(sample_device, mock_ha_client)
+
+    mock_ha_client.update_device_area.assert_called_once_with("z2m-device-id", "kitchen")
+
+
+async def test_step_assign_area_skips_when_no_z2m_device(sample_device, mock_ha_client):
+    """When Z2M device is not yet in HA, area assignment is skipped gracefully."""
+    from zigporter.commands.migrate import _step_assign_area  # noqa: PLC0415
+
+    mock_ha_client.get_z2m_device_id = AsyncMock(return_value=None)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await _step_assign_area(sample_device, mock_ha_client)
+
+    mock_ha_client.get_area_registry.assert_not_called()
+    mock_ha_client.update_device_area.assert_not_called()
+
+
+async def test_prompt_area_returns_none_for_no_area():
+    """Selecting '── No area ──' returns None."""
+    from zigporter.commands.migrate import _prompt_area  # noqa: PLC0415
+
+    device = ZHADevice(
+        device_id="d",
+        ieee="00:11:22:33:44:55:66:77",
+        name="Lamp",
+        device_type="EndDevice",
+        entities=[],
+    )
+    areas = [{"area_id": "bedroom", "name": "Bedroom"}]
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="__no_area__")
+        result = await _prompt_area(device, areas)
+
+    assert result is None
+
+
+async def test_prompt_area_returns_selected_area_id():
+    """Selecting a named area returns its area_id."""
+    from zigporter.commands.migrate import _prompt_area  # noqa: PLC0415
+
+    device = ZHADevice(
+        device_id="d",
+        ieee="00:11:22:33:44:55:66:77",
+        name="Lamp",
+        device_type="EndDevice",
+        entities=[],
+    )
+    areas = [{"area_id": "bedroom", "name": "Bedroom"}]
+
+    with patch("questionary.select") as mock_select:
+        mock_select.return_value.unsafe_ask_async = AsyncMock(return_value="bedroom")
+        result = await _prompt_area(device, areas)
+
+    assert result == "bedroom"
 
 
 async def test_step_validate_all_entities_live(sample_device, mock_ha_client):


### PR DESCRIPTION
## Summary

- Replaces the silent area-restore in step 4 with a live `questionary.select` showing all HA areas
- User can keep the original ZHA area (pre-selected as default), pick a different one, or clear it entirely
- Works for devices that had **no area** in ZHA — previously skipped, now prompts so you can assign one during migration
- Step 4 title updated from "Rename" to "Rename & area" throughout

## Behaviour details

| Scenario | Before | After |
|---|---|---|
| Device had area in ZHA | Silently restored | Shown as default; user can change |
| Device had no area in ZHA | Nothing happened | "No area" pre-selected; user can assign |
| Area no longer exists in HA | Silent failure | Shown as "(no longer exists)" warning |
| `get_area_registry` fails | Silently restored | Fallback: silently restores original area |
| Z2M device not yet in HA | Warning, skip | Warning, skip (unchanged) |

## Test plan

- [ ] 8 new tests: keep area, change area, no-area device assigns area, clear area, registry fetch failure fallback, skip when Z2M device missing, `_prompt_area` returns None for no-area, returns area_id for selection
- [ ] All 585 existing tests still pass
- [ ] `ruff check` + `ruff format --check` clean

## After merge

Run `/update-demo` and update docs to reflect the new step 4 behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)