### PR TITLE
fix(network-map): prevent parent_map cycles in BFS re-placement

### DIFF
--- a/src/zigporter/commands/network_map.py
+++ b/src/zigporter/commands/network_map.py
@@ -210,6 +210,16 @@ async def _resolve_backend(
 # ---------------------------------------------------------------------------
 
 
+def _is_ancestor(candidate: str, of: str, parent_map: dict[str, str | None]) -> bool:
+    """Return True if `candidate` is an ancestor of `of` in the current tree."""
+    cur = parent_map.get(of)
+    while cur is not None:
+        if cur == candidate:
+            return True
+        cur = parent_map.get(cur)
+    return False
+
+
 def _build_routing_tree(
     nodes: dict[str, dict[str, Any]],
     links: list[dict[str, Any]],
@@ -295,6 +305,8 @@ def _build_routing_tree(
                 # Accept both string ("Child") and integer (1) from ZHA/bellows.
                 is_child = 1 if relationship in ("Child", 1) else 0
                 score = (is_child, effective_lqi)
+                if _is_ancestor(ieee, tgt, parent_map):
+                    continue  # would create a cycle — skip
                 if score > best_score:
                     best_score = score
                     best_parent = tgt

--- a/src/zigporter/commands/network_map_svg.py
+++ b/src/zigporter/commands/network_map_svg.py
@@ -150,19 +150,28 @@ def _compute_path_min_lqi(
     parent_map: dict[str, str | None],
     lqi_map: dict[str, int],
 ) -> dict[str, int]:
-    """Min LQI along the full chain from coordinator to each device."""
+    """Min LQI along the full chain from coordinator to each device.
+
+    Iterative to avoid RecursionError on deep chains or cycles in parent_map.
+    A `seen` set breaks any cycle that may exist in the data.
+    """
     cache: dict[str, int] = {}
 
     def _min(ieee: str) -> int:
         if ieee in cache:
             return cache[ieee]
-        parent = parent_map.get(ieee)
-        if parent is None:  # coordinator
-            cache[ieee] = 255
-            return 255
-        link = lqi_map.get(ieee, 0)
-        cache[ieee] = min(link, _min(parent))
-        return cache[ieee]
+        path: list[str] = []
+        seen: set[str] = set()
+        cur: str | None = ieee
+        while cur is not None and cur not in cache and cur not in seen:
+            seen.add(cur)
+            path.append(cur)
+            cur = parent_map.get(cur)
+        base = cache[cur] if cur in cache else 255
+        for node in reversed(path):
+            base = min(lqi_map.get(node, 0), base)
+            cache[node] = base
+        return cache.get(ieee, 0)
 
     for ieee in parent_map:
         _min(ieee)

--- a/tests/commands/test_network_map.py
+++ b/tests/commands/test_network_map.py
@@ -258,6 +258,62 @@ def test_build_routing_tree_empty_links_orphans_attached_to_coordinator():
         assert depth_map[ieee] == 1
 
 
+def test_build_routing_tree_no_cycles():
+    """Re-placement must never create a cycle in parent_map.
+
+    Topology: A → Coordinator (lqi=100), B → A (lqi=200).
+    A second pass finds A → B looks better than A → Coordinator due to lqi,
+    but B is already a descendant of A, so the re-placement must be rejected.
+    """
+    nodes = {
+        "0xcoord": {"type": "Coordinator", "friendlyName": "Coordinator"},
+        "0xa": {"type": "Router", "friendlyName": "Router A"},
+        "0xb": {"type": "Router", "friendlyName": "Router B"},
+    }
+    links = [
+        # A → Coordinator (lqi=100)
+        {"source": {"ieeeAddr": "0xa"}, "target": {"ieeeAddr": "0xcoord"}, "lqi": 100},
+        # Coordinator → A (lqi=100, bidirectional)
+        {"source": {"ieeeAddr": "0xcoord"}, "target": {"ieeeAddr": "0xa"}, "lqi": 100},
+        # B → A (lqi=200)
+        {"source": {"ieeeAddr": "0xb"}, "target": {"ieeeAddr": "0xa"}, "lqi": 200},
+        # A → B (lqi=200) — would form a cycle if A were re-parented to B
+        {"source": {"ieeeAddr": "0xa"}, "target": {"ieeeAddr": "0xb"}, "lqi": 200},
+        # Coordinator → B (lqi=50, lower than B→A)
+        {"source": {"ieeeAddr": "0xcoord"}, "target": {"ieeeAddr": "0xb"}, "lqi": 50},
+        # B → Coordinator (lqi=50)
+        {"source": {"ieeeAddr": "0xb"}, "target": {"ieeeAddr": "0xcoord"}, "lqi": 50},
+    ]
+    parent_map, _, _ = _build_routing_tree(nodes, links)
+
+    # Walk every device's parent chain; no device should appear twice
+    for ieee in nodes:
+        seen: set[str] = set()
+        cur = parent_map.get(ieee)
+        while cur is not None:
+            assert cur not in seen, f"Cycle detected in parent chain of {ieee}: {cur} seen twice"
+            seen.add(cur)
+            cur = parent_map.get(cur)
+
+
+def test_compute_path_min_lqi_cycle_safe():
+    """_compute_path_min_lqi must not recurse/loop infinitely on a cyclic parent_map."""
+    from zigporter.commands.network_map_svg import _compute_path_min_lqi  # noqa: PLC0415
+
+    # Artificially inject a two-node cycle: A → B, B → A
+    parent_map: dict[str, str | None] = {
+        "0xcoord": None,
+        "0xa": "0xb",
+        "0xb": "0xa",
+    }
+    lqi_map = {"0xa": 120, "0xb": 90}
+
+    # Must return without raising and all values must be non-negative
+    result = _compute_path_min_lqi(parent_map, lqi_map)
+    for ieee, val in result.items():
+        assert val >= 0, f"{ieee} has negative path_min_lqi: {val}"
+
+
 # ---------------------------------------------------------------------------
 # Integration tests via run_network_map (captured console output)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes `RecursionError: maximum recursion depth exceeded` crash when running `network-map --output <file>.svg` on certain network topologies (reproduced on a 39-device real network)
- Root cause: the BFS re-placement loop introduced in #47 allowed a node's **descendant** to be selected as its new parent, creating a two-node cycle (`parent_map[A]=B`, `parent_map[B]=A`) that caused `_compute_path_min_lqi` to recurse infinitely

## Root cause (from #47)

Commit 9c9a7ef changed the BFS loop guard from:
```python
if ieee in visited:   # skip already-placed nodes — safe
    continue
```
to:
```python
if nodes[ieee].get("type") == "Coordinator":   # enable re-placement — introduced cycle risk
    continue
```
Re-placement is correct and necessary for ZHA `"Child"` relationships, but without a descendant check it can produce cycles.

## Fix

**`network_map.py`** — prevent cycles at source:
- Add `_is_ancestor(candidate, of, parent_map)` iterative helper
- Call it in the re-placement scoring loop to skip any candidate that is already a descendant of the device being re-placed

**`network_map_svg.py`** — defensive guard in SVG renderer:
- Replace the recursive `_min` inner function in `_compute_path_min_lqi` with an iterative path-walk using a `seen` set to break any cycle that might slip through from unusual Z2M/ZHA data

## Tests

Two new tests added (67 total, all passing):
- `test_build_routing_tree_no_cycles` — constructs a topology where re-placement would create a cycle; asserts no device appears twice in any parent chain
- `test_compute_path_min_lqi_cycle_safe` — passes a synthetic `parent_map` with a hard A→B→A cycle directly to `_compute_path_min_lqi`; asserts no crash and all values ≥ 0

## Test plan
- [x] `uv run pytest tests/commands/test_network_map.py -v` — 67/67 passing
- [x] `uv run ruff check src/zigporter/commands/network_map.py src/zigporter/commands/network_map_svg.py` — clean
- [x] Manual smoke test with ZHA backend
- [x] Manual smoke test with Z2M backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)