### PR TITLE
fix(tests): isolate config tests from host environment

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,15 @@
 import pytest
 
+import zigporter.config
 from zigporter.config import load_config, load_z2m_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_env_loaded(monkeypatch, tmp_path):
+    """Reset the module-level _env_loaded guard and point config_dir to an empty
+    temp directory so the real ~/.config/zigporter/.env never leaks into tests."""
+    monkeypatch.setattr(zigporter.config, "_env_loaded", False)
+    monkeypatch.setattr(zigporter.config, "config_dir", lambda: tmp_path)
 
 
 def test_load_config_from_env(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Add autouse fixture to `test_config.py` that resets the `_env_loaded` module guard and redirects `config_dir` to an empty temp directory
- Fixes flaky `test_load_config_from_env` failure when the host has `HA_VERIFY_SSL=false` in `~/.config/zigporter/.env`

## Test plan

- [x] All 10 config tests pass locally
- [x] Full suite: 645 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)