### PR TITLE
fix(export): handle missing ZHA integration gracefully

### DIFF
--- a/src/zigporter/commands/export.py
+++ b/src/zigporter/commands/export.py
@@ -173,6 +173,13 @@ async def run_export(ha_url: str, token: str, verify_ssl: bool) -> ZHAExport:
         progress.update(t, description="Fetching ZHA + registry data...")
         ws_data = await client.get_all_ws_data()
 
+        if not ws_data["zha_devices"]:
+            progress.stop()
+            console.print(
+                "[yellow]Warning:[/yellow] No ZHA devices found. "
+                "The ZHA integration may not be installed."
+            )
+
         progress.update(t, description="Fetching entity states...")
         states = await client.get_states()
 

--- a/src/zigporter/ha_client.py
+++ b/src/zigporter/ha_client.py
@@ -143,7 +143,7 @@ class HAClient:
                 await ws.send(json.dumps({"id": cmd_id, **command}))
                 msg = json.loads(await ws.recv())
                 if not msg.get("success"):
-                    if key == "automation_configs":
+                    if key in ("automation_configs", "zha_devices"):
                         results[key] = []
                     else:
                         raise RuntimeError(f"WebSocket command '{command['type']}' failed: {msg}")

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -503,17 +503,45 @@ async def test_rename_device_name(client, mocker):
     assert sent["name_by_user"] == "New Name"
 
 
-async def test_get_all_ws_data_non_automation_failure_raises(client, mocker):
-    """Lines 86-89: non-automation command failure raises RuntimeError."""
+async def test_get_all_ws_data_zha_failure_returns_empty(client, mocker):
+    """zha/devices failure returns empty list instead of raising (ZHA not installed)."""
     auth_msgs = [
         json.dumps({"type": "auth_required"}),
         json.dumps({"type": "auth_ok"}),
     ]
+    results = [
+        # zha_devices (id=1) fails
+        json.dumps({"id": 1, "type": "result", "success": False, "error": {"code": "unknown"}}),
+        # remaining commands succeed
+        json.dumps({"id": 2, "type": "result", "success": True, "result": []}),
+        json.dumps({"id": 3, "type": "result", "success": True, "result": []}),
+        json.dumps({"id": 4, "type": "result", "success": True, "result": []}),
+        json.dumps({"id": 5, "type": "result", "success": True, "result": []}),
+    ]
+    mock_ws = mocker.AsyncMock()
+    mock_ws.recv = mocker.AsyncMock(side_effect=auth_msgs + results)
+    mock_ws.__aenter__ = mocker.AsyncMock(return_value=mock_ws)
+    mock_ws.__aexit__ = mocker.AsyncMock(return_value=False)
+    mocker.patch("websockets.connect", return_value=mock_ws)
+
+    data = await client.get_all_ws_data()
+    assert data["zha_devices"] == []
+    assert "entity_registry" in data
+
+
+async def test_get_all_ws_data_non_automation_failure_raises(client, mocker):
+    """Non-graceful command failure (e.g. entity_registry) raises RuntimeError."""
+    auth_msgs = [
+        json.dumps({"type": "auth_required"}),
+        json.dumps({"type": "auth_ok"}),
+    ]
+    # zha_devices (id=1) succeeds, entity_registry (id=2) fails
+    ok_result = json.dumps({"id": 1, "type": "result", "success": True, "result": []})
     fail_result = json.dumps(
-        {"id": 1, "type": "result", "success": False, "error": {"code": "unknown"}}
+        {"id": 2, "type": "result", "success": False, "error": {"code": "unknown"}}
     )
     mock_ws = mocker.AsyncMock()
-    mock_ws.recv = mocker.AsyncMock(side_effect=auth_msgs + [fail_result])
+    mock_ws.recv = mocker.AsyncMock(side_effect=auth_msgs + [ok_result, fail_result])
     mock_ws.__aenter__ = mocker.AsyncMock(return_value=mock_ws)
     mock_ws.__aexit__ = mocker.AsyncMock(return_value=False)
     mocker.patch("websockets.connect", return_value=mock_ws)


### PR DESCRIPTION
## Summary

- `zigporter export` crashed with `RuntimeError: WebSocket command 'zha/devices' failed` when the ZHA integration was not installed (e.g. user fully migrated to Z2M)
- Now gracefully returns an empty device list and prints a warning instead of crashing
- Added test for the new graceful ZHA failure path

## Test plan

- [x] All 561 tests pass
- [ ] Verify on a HA instance without ZHA that `zigporter export` completes with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)