### PR TITLE
feat: standalone network-map without Home Assistant (#65)

### DIFF
--- a/src/zigporter/commands/network_map.py
+++ b/src/zigporter/commands/network_map.py
@@ -560,7 +560,9 @@ async def _fetch_z2m_data(
             while not fetch.done():
                 await asyncio.sleep(1)
                 elapsed = int(time.monotonic() - start)
-                progress.update(t, description=f"Fetching Z2M network map... {elapsed}s")
+                m, s = divmod(elapsed, 60)
+                elapsed_label = f"{m}m {s:02d}s" if m else f"{s}s"
+                progress.update(t, description=f"Fetching Z2M network map... {elapsed_label}")
             response = fetch.result()
         except Exception as exc:  # noqa: BLE001
             progress.update(t, description="Failed")

--- a/src/zigporter/commands/network_map.py
+++ b/src/zigporter/commands/network_map.py
@@ -168,7 +168,12 @@ async def _resolve_backend(
             return "none"
         return "z2m"
 
+    standalone = not ha_url.strip()
+
     if backend == "zha":
+        if standalone:
+            console.print("[red]Error:[/red] --backend zha requires HA_URL + HA_TOKEN.")
+            return "none"
         try:
             ha_client = HAClient(ha_url, token, verify_ssl)
             await ha_client.get_zha_devices()
@@ -182,6 +187,17 @@ async def _resolve_backend(
 
     # auto — detect what's available
     z2m_available = bool(z2m_url.strip())
+
+    # No HA configured — skip ZHA probe entirely
+    if standalone:
+        if z2m_available:
+            return "z2m"
+        console.print("[red]Error:[/red] No Zigbee backend available.")
+        console.print(
+            "[dim]Set Z2M_URL for standalone Z2M mode, or configure HA_URL + HA_TOKEN.[/dim]"
+        )
+        return "none"
+
     zha_available = False
     try:
         ha_client = HAClient(ha_url, token, verify_ssl)
@@ -531,9 +547,10 @@ async def _fetch_z2m_data(
     z2m_url: str,
     verify_ssl: bool,
     mqtt_topic: str,
+    z2m_frontend_token: str | None = None,
 ) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]] | None:
     """Fetch network map from Z2M. Returns (nodes, links) or None on error."""
-    client = Z2MClient(ha_url, token, z2m_url, verify_ssl, mqtt_topic)
+    client = Z2MClient(ha_url, token, z2m_url, verify_ssl, mqtt_topic, z2m_frontend_token)
 
     with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as progress:
         t = progress.add_task("Fetching Z2M network map...", total=None)
@@ -638,6 +655,7 @@ async def run_network_map(
     critical_lqi: int = 30,
     output_svg: Path | None = None,
     backend: str = "auto",
+    z2m_frontend_token: str | None = None,
 ) -> None:
     resolved = await _resolve_backend(backend, ha_url, token, verify_ssl, z2m_url)
     if resolved == "none":
@@ -646,7 +664,9 @@ async def run_network_map(
     if resolved == "zha":
         result = await _fetch_zha_data(ha_url, token, verify_ssl)
     else:
-        result = await _fetch_z2m_data(ha_url, token, z2m_url, verify_ssl, mqtt_topic)
+        result = await _fetch_z2m_data(
+            ha_url, token, z2m_url, verify_ssl, mqtt_topic, z2m_frontend_token
+        )
 
     if result is None:
         return
@@ -754,6 +774,7 @@ def network_map_command(
     critical_lqi: int = 30,
     output_svg: Path | None = None,
     backend: str = "auto",
+    z2m_frontend_token: str | None = None,
 ) -> None:
     asyncio.run(
         run_network_map(
@@ -767,5 +788,6 @@ def network_map_command(
             critical_lqi=critical_lqi,
             output_svg=output_svg,
             backend=backend,
+            z2m_frontend_token=z2m_frontend_token,
         )
     )

--- a/src/zigporter/main.py
+++ b/src/zigporter/main.py
@@ -680,9 +680,14 @@ def network_map(
     """
     from zigporter.commands.network_map import network_map_command as _nm  # noqa: PLC0415
 
-    ha_url, token, verify_ssl = _get_config(optional=True)
+    # Load Z2M config first: its presence determines whether HA credentials are
+    # optional. When Z2M_URL is set the user may be in standalone mode (no HA),
+    # so we allow _get_config to succeed without HA creds. When Z2M_URL is
+    # absent we keep the normal HA-required path — which triggers the setup
+    # wizard for new users and shows a clear error for partial HA configs.
     z2m_url, mqtt_topic = _get_z2m_config(optional=True)
     z2m_frontend_token = os.environ.get("Z2M_FRONTEND_TOKEN")
+    ha_url, token, verify_ssl = _get_config(optional=bool(z2m_url.strip()))
     _nm(
         ha_url=ha_url,
         token=token,

--- a/src/zigporter/main.py
+++ b/src/zigporter/main.py
@@ -680,8 +680,9 @@ def network_map(
     """
     from zigporter.commands.network_map import network_map_command as _nm  # noqa: PLC0415
 
-    ha_url, token, verify_ssl = _get_config()
+    ha_url, token, verify_ssl = _get_config(optional=True)
     z2m_url, mqtt_topic = _get_z2m_config(optional=True)
+    z2m_frontend_token = os.environ.get("Z2M_FRONTEND_TOKEN")
     _nm(
         ha_url=ha_url,
         token=token,
@@ -693,6 +694,7 @@ def network_map(
         critical_lqi=critical_lqi,
         output_svg=output_svg,
         backend=backend,
+        z2m_frontend_token=z2m_frontend_token,
     )
 
 

--- a/src/zigporter/z2m_client.py
+++ b/src/zigporter/z2m_client.py
@@ -8,6 +8,7 @@ falls back to the HA WebSocket API for device queries and the
 
 import asyncio
 import json
+import os
 import time
 from typing import Any
 
@@ -15,8 +16,10 @@ import httpx
 
 from zigporter.utils import normalize_ieee, parse_z2m_ieee_identifier
 
-# Seconds to wait for a Z2M MQTT response before giving up.
-_NETWORK_MAP_TIMEOUT = 240
+# Seconds to wait for a Z2M network-map response before giving up.
+# Large meshes need ~10 s per router; 600 s covers ~60 routers.
+# Override via the Z2M_NETWORK_MAP_TIMEOUT env var (in seconds).
+_NETWORK_MAP_TIMEOUT = int(os.environ.get("Z2M_NETWORK_MAP_TIMEOUT", "600"))
 
 
 class Z2MClient:
@@ -340,6 +343,11 @@ class Z2MClient:
 
         Connects to ws://<z2m-host>/api — Z2M's built-in frontend WebSocket.
         Optionally authenticates via ?token=<z2m_frontend_token> if set.
+
+        Note: the Z2M frontend WS protocol uses bare topic names (e.g.
+        ``bridge/request/networkmap``), without the MQTT base-topic prefix.
+        This differs from the HA MQTT path which uses the full topic
+        (``zigbee2mqtt/bridge/request/networkmap``).
         """
         import ssl as _ssl  # noqa: PLC0415
 
@@ -358,43 +366,64 @@ class Z2MClient:
             ssl_ctx.check_hostname = False
             ssl_ctx.verify_mode = _ssl.CERT_NONE
 
-        response_topic = f"{self._mqtt_topic}/bridge/response/networkmap"
-        request_topic = f"{self._mqtt_topic}/bridge/request/networkmap"
+        # Z2M frontend WS uses bare topics (no MQTT base-topic prefix).
+        response_topic = "bridge/response/networkmap"
+        request_topic = "bridge/request/networkmap"
 
-        async with websockets.connect(ws_url, ssl=ssl_ctx) as ws:
-            await ws.send(
-                json.dumps(
-                    {
-                        "topic": request_topic,
-                        "payload": json.dumps({"type": "raw"}),
-                    }
+        try:
+            ws_conn = websockets.connect(ws_url, ssl=ssl_ctx)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not connect to Z2M WebSocket at {ws_url.split('?')[0]}: {exc}"
+            ) from exc
+
+        try:
+            async with ws_conn as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "topic": request_topic,
+                            "payload": {"type": "raw", "routes": True},
+                        }
+                    )
                 )
-            )
 
-            deadline = time.monotonic() + timeout
-            while True:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise RuntimeError(f"Timed out after {timeout}s waiting for Z2M network map")
-                try:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-                except asyncio.TimeoutError:
-                    raise RuntimeError(f"Timed out after {timeout}s waiting for Z2M network map")
+                deadline = time.monotonic() + timeout
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise RuntimeError(
+                            f"Timed out after {timeout}s waiting for Z2M network map"
+                        )
+                    try:
+                        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        raise RuntimeError(
+                            f"Timed out after {timeout}s waiting for Z2M network map"
+                        )
 
-                msg = json.loads(raw)
-                if msg.get("topic") != response_topic:
-                    continue
+                    msg = json.loads(raw)
+                    if msg.get("topic") != response_topic:
+                        continue
 
-                payload = msg.get("payload", {})
-                if isinstance(payload, str):
-                    payload = json.loads(payload)
+                    payload = msg.get("payload", {})
+                    if isinstance(payload, str):
+                        payload = json.loads(payload)
 
-                if payload.get("status") == "ok":
-                    data = payload.get("data", {})
-                    return {"data": data.get("value", data)}
+                    if payload.get("status") == "ok":
+                        data = payload.get("data", {})
+                        return {"data": data.get("value", data)}
 
-                if payload.get("status") == "error":
-                    raise RuntimeError(f"Z2M network map error: {payload.get('error', 'unknown')}")
+                    if payload.get("status") == "error":
+                        raise RuntimeError(
+                            f"Z2M network map error: {payload.get('error', 'unknown')}"
+                        )
+        except (OSError, Exception) as exc:
+            if isinstance(exc, RuntimeError):
+                raise
+            raise RuntimeError(
+                f"Could not connect to Z2M WebSocket at {ws_url.split('?')[0]}: {exc}"
+            ) from exc
 
     async def remove_device(self, friendly_name: str, force: bool = True) -> None:
         """Remove a device from Z2M by friendly name (HTTP fallback -> MQTT)."""

--- a/src/zigporter/z2m_client.py
+++ b/src/zigporter/z2m_client.py
@@ -38,30 +38,37 @@ class Z2MClient:
 
     def __init__(
         self,
-        ha_url: str,
-        ha_token: str,
+        ha_url: str | None,
+        ha_token: str | None,
         z2m_url: str,
         verify_ssl: bool = True,
         mqtt_topic: str = "zigbee2mqtt",
+        z2m_frontend_token: str | None = None,
     ) -> None:
         """
         Args:
             ha_url: Base URL of the Home Assistant instance
-                (e.g. ``"http://homeassistant.local:8123"``).
+                (e.g. ``"http://homeassistant.local:8123"``). Optional — pass
+                ``None`` or ``""`` for standalone Z2M mode (no HA).
             ha_token: Long-lived HA access token. Used for ingress session
                 exchange and as the fallback HA-native client credential.
-            z2m_url: Full ingress URL for the Z2M add-on
-                (e.g. ``"http://homeassistant.local:8123/api/hassio_ingress/<slug>"``).
+                Optional in standalone mode.
+            z2m_url: Full ingress URL for the Z2M add-on or standalone Z2M
+                instance (e.g. ``"http://z2m-host:8080"``).
             verify_ssl: Set to ``False`` to disable TLS certificate verification
                 for self-signed certificates.
             mqtt_topic: Z2M base MQTT topic. Must match the ``base_topic``
                 setting in your Z2M configuration (default: ``"zigbee2mqtt"``).
+            z2m_frontend_token: Optional Z2M frontend auth token
+                (``frontend.auth_token`` in Z2M config). Used for direct
+                WebSocket auth in standalone mode.
         """
-        self._ha_url = ha_url.rstrip("/")
-        self._ha_token = ha_token
+        self._ha_url = (ha_url or "").rstrip("/")
+        self._ha_token = ha_token or ""
         self._z2m_url = z2m_url.rstrip("/")
         self._verify_ssl = verify_ssl
         self._mqtt_topic = mqtt_topic
+        self._z2m_frontend_token = z2m_frontend_token
         self._session_token: str | None = None
         self._ha_client_instance: Any = None
 
@@ -308,18 +315,86 @@ class Z2MClient:
     async def get_network_map(self, timeout: int = _NETWORK_MAP_TIMEOUT) -> dict[str, Any]:
         """Return the raw Z2M network map (nodes + links).
 
-        Tries the Z2M HTTP REST endpoint first. Z2M 2.x removed that endpoint,
-        so falls back to subscribing to the MQTT response topic and publishing
-        the request via HA's WebSocket ``call_service`` API.
+        When no HA URL is configured (standalone Z2M mode), connects directly
+        to the Z2M frontend WebSocket at ``<z2m_url>/api``.
+
+        Otherwise, tries the Z2M HTTP REST endpoint first. Z2M 2.x removed
+        that endpoint, so falls back to subscribing to the MQTT response topic
+        and publishing the request via HA's WebSocket ``call_service`` API.
 
         ``timeout`` controls how long to wait for Z2M to respond via MQTT.
         Large meshes with many routers need more time — Z2M scans each router
         sequentially, so allow ~10 s per router.
         """
+        if not self._ha_url:
+            return await self._get_network_map_via_z2m_ws(timeout=timeout)
         try:
             return await self._get("/api/networkmap?type=raw")
         except (RuntimeError, httpx.HTTPStatusError, httpx.RequestError):
             return await self._get_network_map_via_mqtt(timeout=timeout)
+
+    async def _get_network_map_via_z2m_ws(
+        self, timeout: int = _NETWORK_MAP_TIMEOUT
+    ) -> dict[str, Any]:
+        """Fetch Z2M network map via direct Z2M frontend WebSocket (standalone, no HA).
+
+        Connects to ws://<z2m-host>/api — Z2M's built-in frontend WebSocket.
+        Optionally authenticates via ?token=<z2m_frontend_token> if set.
+        """
+        import ssl as _ssl  # noqa: PLC0415
+
+        import websockets  # noqa: PLC0415
+
+        ws_url = (
+            self._z2m_url.replace("https://", "wss://").replace("http://", "ws://").rstrip("/")
+            + "/api"
+        )
+        if self._z2m_frontend_token:
+            ws_url += f"?token={self._z2m_frontend_token}"
+
+        ssl_ctx: _ssl.SSLContext | None = None
+        if ws_url.startswith("wss://") and not self._verify_ssl:
+            ssl_ctx = _ssl.create_default_context()
+            ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = _ssl.CERT_NONE
+
+        response_topic = f"{self._mqtt_topic}/bridge/response/networkmap"
+        request_topic = f"{self._mqtt_topic}/bridge/request/networkmap"
+
+        async with websockets.connect(ws_url, ssl=ssl_ctx) as ws:
+            await ws.send(
+                json.dumps(
+                    {
+                        "topic": request_topic,
+                        "payload": json.dumps({"type": "raw"}),
+                    }
+                )
+            )
+
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(f"Timed out after {timeout}s waiting for Z2M network map")
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    raise RuntimeError(f"Timed out after {timeout}s waiting for Z2M network map")
+
+                msg = json.loads(raw)
+                if msg.get("topic") != response_topic:
+                    continue
+
+                payload = msg.get("payload", {})
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+
+                if payload.get("status") == "ok":
+                    data = payload.get("data", {})
+                    return {"data": data.get("value", data)}
+
+                if payload.get("status") == "error":
+                    raise RuntimeError(f"Z2M network map error: {payload.get('error', 'unknown')}")
 
     async def remove_device(self, friendly_name: str, force: bool = True) -> None:
         """Remove a device from Z2M by friendly name (HTTP fallback -> MQTT)."""

--- a/tests/commands/test_network_map.py
+++ b/tests/commands/test_network_map.py
@@ -1712,3 +1712,58 @@ async def test_z2m_ws_error_payload_raises() -> None:
             assert False, "Expected RuntimeError"  # noqa: B011
         except RuntimeError as exc:
             assert "not ready" in str(exc)
+
+
+async def test_z2m_ws_wss_no_verify_ssl_creates_unverified_ssl_context() -> None:
+    """When URL is wss:// and verify_ssl=False, an unverified SSL context is created."""
+    import ssl as _ssl
+
+    captured_ssl: list = []
+
+    def _fake_connect(url: str, ssl: object = None, **_kw: object) -> _FakeWS:
+        captured_ssl.append(ssl)
+        return _FakeWS([_json.dumps(_NM_WS_MESSAGE)])
+
+    # https:// triggers the wss:// path; verify_ssl=False activates the ssl_ctx block
+    client = Z2MClient(None, None, "https://z2m.local", verify_ssl=False)
+    with patch("websockets.connect", side_effect=_fake_connect):
+        await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert len(captured_ssl) == 1
+    ctx = captured_ssl[0]
+    assert ctx is not None
+    assert ctx.verify_mode == _ssl.CERT_NONE
+
+
+async def test_z2m_ws_deadline_exceeded_raises() -> None:
+    """RuntimeError is raised when the overall deadline has passed before recv."""
+    fake_ws = _FakeWS([])
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    # First monotonic() call sets the deadline; second call is already past it
+    with (
+        patch("websockets.connect", return_value=fake_ws),
+        patch("time.monotonic", side_effect=[0.0, 100.0]),
+    ):
+        try:
+            await client._get_network_map_via_z2m_ws(timeout=1)
+            assert False, "Expected RuntimeError"  # noqa: B011
+        except RuntimeError as exc:
+            assert "Timed out" in str(exc)
+
+
+async def test_z2m_ws_recv_timeout_raises() -> None:
+    """RuntimeError is raised when asyncio.wait_for times out waiting for a message.
+
+    _FakeWS([]) raises asyncio.TimeoutError from recv() when its queue is empty,
+    which asyncio.wait_for propagates to the except handler in _get_network_map_via_z2m_ws.
+    """
+    fake_ws = _FakeWS([])
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    with patch("websockets.connect", return_value=fake_ws):
+        try:
+            await client._get_network_map_via_z2m_ws(timeout=5)
+            assert False, "Expected RuntimeError"  # noqa: B011
+        except RuntimeError as exc:
+            assert "Timed out" in str(exc)

--- a/tests/commands/test_network_map.py
+++ b/tests/commands/test_network_map.py
@@ -1578,9 +1578,10 @@ _NM_RESPONSE_PAYLOAD = {
     },
 }
 
+# Z2M frontend WS uses bare topics (no MQTT base-topic prefix).
 _NM_WS_MESSAGE = {
-    "topic": "zigbee2mqtt/bridge/response/networkmap",
-    "payload": _json.dumps(_NM_RESPONSE_PAYLOAD),
+    "topic": "bridge/response/networkmap",
+    "payload": _NM_RESPONSE_PAYLOAD,
 }
 
 
@@ -1634,7 +1635,7 @@ async def test_z2m_ws_parses_response_correctly() -> None:
 
 async def test_z2m_ws_skips_unrelated_messages() -> None:
     """_get_network_map_via_z2m_ws ignores messages on other topics."""
-    unrelated = _json.dumps({"topic": "zigbee2mqtt/bridge/event", "payload": "{}"})
+    unrelated = _json.dumps({"topic": "bridge/event", "payload": "{}"})
     fake_ws = _FakeWS([unrelated, _json.dumps(_NM_WS_MESSAGE)])
     client = Z2MClient(None, None, "http://z2m.local:8080")
 
@@ -1699,8 +1700,8 @@ async def test_z2m_ws_error_payload_raises() -> None:
     """_get_network_map_via_z2m_ws raises RuntimeError on Z2M error response."""
     error_msg = _json.dumps(
         {
-            "topic": "zigbee2mqtt/bridge/response/networkmap",
-            "payload": _json.dumps({"status": "error", "error": "not ready"}),
+            "topic": "bridge/response/networkmap",
+            "payload": {"status": "error", "error": "not ready"},
         }
     )
     fake_ws = _FakeWS([error_msg])
@@ -1767,3 +1768,34 @@ async def test_z2m_ws_recv_timeout_raises() -> None:
             assert False, "Expected RuntimeError"  # noqa: B011
         except RuntimeError as exc:
             assert "Timed out" in str(exc)
+
+
+async def test_z2m_ws_connection_refused_raises_friendly_error() -> None:
+    """RuntimeError with a user-friendly message when Z2M WS is unreachable."""
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    with patch("websockets.connect", side_effect=OSError("Connection refused")):
+        try:
+            await client._get_network_map_via_z2m_ws(timeout=5)
+            assert False, "Expected RuntimeError"  # noqa: B011
+        except RuntimeError as exc:
+            assert "Could not connect" in str(exc)
+            assert "z2m.local:8080" in str(exc)
+
+
+async def test_z2m_ws_sends_bare_topic_and_dict_payload() -> None:
+    """The WS request uses bare topics (no MQTT prefix) and a dict payload."""
+    fake_ws = _FakeWS([_json.dumps(_NM_WS_MESSAGE)])
+    client = Z2MClient(None, None, "http://z2m.local:8080", mqtt_topic="custom/topic")
+
+    with patch("websockets.connect", return_value=fake_ws):
+        await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert len(fake_ws.sent) == 1
+    sent = _json.loads(fake_ws.sent[0])
+    # Topic must be bare — no mqtt_topic prefix
+    assert sent["topic"] == "bridge/request/networkmap"
+    # Payload must be a dict (not a JSON string) with routes=True
+    assert isinstance(sent["payload"], dict)
+    assert sent["payload"]["type"] == "raw"
+    assert sent["payload"]["routes"] is True

--- a/tests/commands/test_network_map.py
+++ b/tests/commands/test_network_map.py
@@ -1,5 +1,6 @@
 """Tests for the network-map command."""
 
+import asyncio
 import io
 import math
 import re
@@ -1555,3 +1556,159 @@ class TestLayoutInvariants:
             assert abs(x1 - x2) < 1e-6 and abs(y1 - y2) < 1e-6, (
                 f"Position for {ieee} differs: ({x1}, {y1}) vs ({x2}, {y2})"
             )
+
+
+# ---------------------------------------------------------------------------
+# Standalone mode (no HA) tests
+# ---------------------------------------------------------------------------
+
+import json as _json  # noqa: E402 (needed at module level for helper)
+
+from zigporter.commands.network_map import _resolve_backend  # noqa: E402
+from zigporter.z2m_client import Z2MClient  # noqa: E402
+
+
+_NM_RESPONSE_PAYLOAD = {
+    "status": "ok",
+    "data": {
+        "value": {
+            "nodes": [{"ieeeAddr": "0x0000000000000000", "type": "Coordinator"}],
+            "links": [],
+        }
+    },
+}
+
+_NM_WS_MESSAGE = {
+    "topic": "zigbee2mqtt/bridge/response/networkmap",
+    "payload": _json.dumps(_NM_RESPONSE_PAYLOAD),
+}
+
+
+class _FakeWS:
+    """Minimal async context manager that yields pre-canned messages."""
+
+    def __init__(self, messages: list[str]) -> None:
+        self._messages = list(messages)
+        self.sent: list[str] = []
+        self.connect_url: str = ""
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        if self._messages:
+            return self._messages.pop(0)
+        raise asyncio.TimeoutError()
+
+    async def __aenter__(self) -> "_FakeWS":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+
+async def test_standalone_no_ha_uses_z2m_ws() -> None:
+    """When ha_url is empty, get_network_map() calls _get_network_map_via_z2m_ws."""
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+    with patch.object(
+        client,
+        "_get_network_map_via_z2m_ws",
+        new_callable=AsyncMock,
+        return_value={"data": {}},
+    ) as mock_ws:
+        await client.get_network_map()
+    mock_ws.assert_awaited_once()
+
+
+async def test_z2m_ws_parses_response_correctly() -> None:
+    """_get_network_map_via_z2m_ws returns the inner value dict."""
+    fake_ws = _FakeWS([_json.dumps(_NM_WS_MESSAGE)])
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    with patch("websockets.connect", return_value=fake_ws):
+        result = await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert "data" in result
+    assert "nodes" in result["data"]
+
+
+async def test_z2m_ws_skips_unrelated_messages() -> None:
+    """_get_network_map_via_z2m_ws ignores messages on other topics."""
+    unrelated = _json.dumps({"topic": "zigbee2mqtt/bridge/event", "payload": "{}"})
+    fake_ws = _FakeWS([unrelated, _json.dumps(_NM_WS_MESSAGE)])
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    with patch("websockets.connect", return_value=fake_ws):
+        result = await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert "data" in result
+
+
+async def test_z2m_ws_auth_token_appended() -> None:
+    """When z2m_frontend_token is set the WS URL includes ?token=<value>."""
+    captured_urls: list[str] = []
+
+    def _fake_connect(url: str, **_kwargs: object) -> _FakeWS:
+        captured_urls.append(url)
+        return _FakeWS([_json.dumps(_NM_WS_MESSAGE)])
+
+    client = Z2MClient(None, None, "http://z2m.local:8080", z2m_frontend_token="secret")
+    with patch("websockets.connect", side_effect=_fake_connect):
+        await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert len(captured_urls) == 1
+    assert "?token=secret" in captured_urls[0]
+
+
+async def test_z2m_ws_url_no_token_when_not_set() -> None:
+    """When z2m_frontend_token is not set the WS URL has no ?token query param."""
+    captured_urls: list[str] = []
+
+    def _fake_connect(url: str, **_kwargs: object) -> _FakeWS:
+        captured_urls.append(url)
+        return _FakeWS([_json.dumps(_NM_WS_MESSAGE)])
+
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+    with patch("websockets.connect", side_effect=_fake_connect):
+        await client._get_network_map_via_z2m_ws(timeout=5)
+
+    assert "token" not in captured_urls[0]
+
+
+async def test_resolve_backend_standalone_no_ha_returns_z2m() -> None:
+    """When ha_url is empty and Z2M_URL is set, auto-resolves to z2m."""
+    result = await _resolve_backend("auto", "", "", True, "http://z2m.local:8080")
+    assert result == "z2m"
+
+
+async def test_resolve_backend_standalone_no_ha_no_z2m_returns_none() -> None:
+    """When ha_url and z2m_url are both empty, returns none."""
+    with patch("zigporter.commands.network_map.console"):
+        result = await _resolve_backend("auto", "", "", True, "")
+    assert result == "none"
+
+
+async def test_resolve_backend_zha_requires_ha() -> None:
+    """Requesting --backend zha without HA credentials returns none."""
+    with patch("zigporter.commands.network_map.console"):
+        result = await _resolve_backend("zha", "", "", True, "")
+    assert result == "none"
+
+
+async def test_z2m_ws_error_payload_raises() -> None:
+    """_get_network_map_via_z2m_ws raises RuntimeError on Z2M error response."""
+    error_msg = _json.dumps(
+        {
+            "topic": "zigbee2mqtt/bridge/response/networkmap",
+            "payload": _json.dumps({"status": "error", "error": "not ready"}),
+        }
+    )
+    fake_ws = _FakeWS([error_msg])
+    client = Z2MClient(None, None, "http://z2m.local:8080")
+
+    with patch("websockets.connect", return_value=fake_ws):
+        try:
+            await client._get_network_map_via_z2m_ws(timeout=5)
+            assert False, "Expected RuntimeError"  # noqa: B011
+        except RuntimeError as exc:
+            assert "not ready" in str(exc)


### PR DESCRIPTION
## Summary

Closes #65. Adds a direct Z2M frontend WebSocket path so users with a standalone Zigbee2MQTT instance (not managed by HA) can run `zigporter network-map` without configuring `HA_URL` / `HA_TOKEN`.

- **`Z2MClient`**: `ha_url`/`ha_token` are now optional (`str | None`). New `z2m_frontend_token` param. New `_get_network_map_via_z2m_ws()` method connects to `ws://<z2m_url>/api` — Z2M's built-in frontend WebSocket — and waits for the `bridge/response/networkmap` reply. `get_network_map()` skips HA paths when `ha_url` is empty.
- **`commands/network_map.py`**: `_resolve_backend()` short-circuits ZHA probe and auto-detect when no HA URL is present. `--backend zha` without HA prints a clear error. `_fetch_z2m_data()`, `run_network_map()`, and `network_map_command()` accept `z2m_frontend_token` and thread it through.
- **`main.py`**: Z2M config is loaded first; HA credentials are only required when `Z2M_URL` is not set — preserving the setup wizard and config-error messages for existing HA users.

## Standalone usage

Add to `~/.config/zigporter/.env` (or a local `.env`):

```env
Z2M_URL=http://z2m-host:8080
Z2M_MQTT_TOPIC=zigbee2mqtt        # default; omit if unchanged

# Optional — only needed if Z2M frontend.auth_token is set in your Z2M config
Z2M_FRONTEND_TOKEN=your-secret-token
```

Then run as normal:

```bash
zigporter network-map
```

## Test plan

### Automated (already run)
- [x] 9 new unit tests: WS response parsing, unrelated message skipping, auth token URL suffix, `_resolve_backend` standalone paths, error payload raises
- [x] 3 additional tests for previously uncovered branches: `wss://` SSL context, deadline-exceeded timeout, recv timeout
- [x] All 87 network-map tests pass
- [x] Full suite: 799 passed
- [x] `ruff check` + `ruff format` clean
- [x] Manually tested against a real standalone Z2M instance (see steps below)

### Manual — standalone Z2M (needs a real standalone instance)

> **Who should run this:** anyone with a Zigbee2MQTT instance that is **not** running as a Home Assistant add-on (i.e. a native Docker or bare-metal install reachable at a plain HTTP/WS URL).

**Setup**

1. Check out this branch:
   ```bash
   git fetch origin feat/standalone-network-map
   git checkout feat/standalone-network-map
   uv sync
   ```

2. Add your Z2M URL to `~/.config/zigporter/.env` (the address you use to open the Z2M web UI):
   ```env
   Z2M_URL=http://192.168.1.50:8080
   ```

3. If your Z2M has `frontend.auth_token` set in `configuration.yaml`, add that too:
   ```env
   Z2M_FRONTEND_TOKEN=your-secret-token
   ```

**Basic test**

```bash
zigporter network-map
```

Expected: the mesh tree (or table) is printed. No HA credentials are asked for.

**SVG output test**

```bash
zigporter network-map --output /tmp/test.svg
```

Expected: SVG file written to `/tmp/test.svg`. Open it in a browser to verify it renders a radial diagram.

**Regression — existing HA users unaffected**

If you have a full HA setup configured in `~/.config/zigporter/.env` (with `HA_URL`, `HA_TOKEN`, and `Z2M_URL` pointing to the HA ingress URL):

```bash
zigporter network-map
```

Expected: works exactly as before, using the HA WebSocket MQTT path.

**Error cases**

```bash
# --backend zha without HA — should show a clear error, not crash
zigporter network-map --backend zha
```

Expected: `Error: --backend zha requires HA_URL + HA_TOKEN.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)