### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/brew-publish.yml
+++ b/.github/workflows/brew-publish.yml
@@ -1,5 +1,8 @@
 name: Brew Publish (manual rerun)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/nordstad/zigporter/security/code-scanning/2](https://github.com/nordstad/zigporter/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. This workflow reads from the repository (via `actions/checkout`) but uses `secrets.HOMEBREW_TAP_TOKEN` for write operations, so `contents: read` is sufficient. No other scopes (issues, pull-requests, packages, etc.) are used.

The best fix without changing existing behavior is to add a workflow-level `permissions` block near the top of `.github/workflows/brew-publish.yml`, after the `name:` and before `on:`. This will apply to all jobs (currently just `update-homebrew`) and restrict the implicit `GITHUB_TOKEN` to read-only repository contents. No imports or additional methods are required; it is a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/brew-publish.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Brew Publish (manual rerun)`) and line 3 (`on:`). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
